### PR TITLE
ol - added placeholder job to milk cows on backend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -66,7 +66,7 @@ public class JobsController extends ApiController {
 
     @ApiOperation(value = "Launch Job to Milk the Cows")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @GetMapping("/launch/testjob")
+    @POSTMapping("/launch/testjob")
     public Job jobMilkCows() 
     {
         return jobService.runAsJob(ctx -> {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -66,7 +66,7 @@ public class JobsController extends ApiController {
 
     @ApiOperation(value = "Launch Job to Milk the Cows")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PostMapping("")
+    @PostMapping("/launch/milkcows")
     public Job jobMilkCows() 
     {
         return jobService.runAsJob(ctx -> {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -66,7 +66,7 @@ public class JobsController extends ApiController {
 
     @ApiOperation(value = "Launch Job to Milk the Cows")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @POSTMapping("/launch/testjob")
+    @PostMapping("")
     public Job jobMilkCows() 
     {
         return jobService.runAsJob(ctx -> {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -64,4 +64,16 @@ public class JobsController extends ApiController {
           });
     }
 
+    @ApiOperation(value = "Launch Job to Milk the Cows")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/launch/testjob")
+    public Job jobMilkCows() 
+    {
+        return jobService.runAsJob(ctx -> {
+            ctx.log("Starting to milk the cows");
+            ctx.log("This is where the code to milk the cows will go.");
+            ctx.log("Cows have been milked!");
+          });
+    }
+
 }


### PR DESCRIPTION
In this PR, we added the placeholder job to launch milk cows on backend in the JobsController

![image](https://user-images.githubusercontent.com/56096858/202595383-9f5f3666-6337-4e06-8d0f-5d65f6c1ea78.png)


Can be tested by either launching on localhost or Heroku, logging in as admin, going to swagger-ui, under jobs-controller, we should find a /api/jobs/launch/milkcows endpoint