### PR TITLE
Modified Footer Github Link to Link from System Info Source Repo

### DIFF
--- a/frontend/src/fixtures/systemInfoFixtures.js
+++ b/frontend/src/fixtures/systemInfoFixtures.js
@@ -2,12 +2,14 @@ const systemInfoFixtures = {
     showingBoth:
     {
         "springH2ConsoleEnabled": true,
-        "showSwaggerUILink": true
+        "showSwaggerUILink": true,
+        "sourceRepo": "https://github.com/ucsb-cs156-f22/f22-5pm-happycows"
     },
     showingNeither:
     {
         "springH2ConsoleEnabled": false,
-        "showSwaggerUILink": false
+        "showSwaggerUILink": false,
+        "sourceRepo": "https://github.com/ucsb-cs156-f22/f22-5pm-happycows"
     }
 };
 

--- a/frontend/src/main/components/Nav/Footer.js
+++ b/frontend/src/main/components/Nav/Footer.js
@@ -1,13 +1,13 @@
 import { Container } from "react-bootstrap";
 
-export default function Footer() {
+export default function Footer({systemInfo}) {
   return (
     <footer className="bg-light pt-3 pt-md-4 pb-4 pb-md-5">
       <Container>
         <p data-testid="footer-content">
           HappierCows is a project of <a href="https://devries.chem.ucsb.edu/mattanjah-de-vries">Mattanjah de Vries</a>, 
           Distinguished Professor of Chemistry at UC Santa Barbara. 
-          The open source code is available on <a href="https://github.com/ucsb-cs156-s22/s22-6pm-happycows">GitHub</a>. 
+          The open source code is available on <a data-testid="github-href" href={systemInfo?.sourceRepo}>GitHub</a>. 
         </p>
         
       </Container>

--- a/frontend/src/main/layouts/BasicLayout/BasicLayout.js
+++ b/frontend/src/main/layouts/BasicLayout/BasicLayout.js
@@ -17,7 +17,7 @@ export default function BasicLayout({ children }) {
       <Container expand="xl" className="pt-4 flex-grow-1">
         {children}
       </Container>
-      <Footer />
+      <Footer systemInfo={systemInfo}/>
     </div>
   );
 }

--- a/frontend/src/stories/layouts/BasicLayout/Footer.stories.js
+++ b/frontend/src/stories/layouts/BasicLayout/Footer.stories.js
@@ -2,6 +2,7 @@
 import React from 'react';
 
 import Footer from "main/components/Nav/Footer";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 export default {
     title: 'layouts/BasicLayout/Footer',
@@ -11,7 +12,7 @@ export default {
 
 const Template = () => {
     return (
-        <Footer />
+        <Footer systemInfo={systemInfoFixtures.showingBoth}/>
     )
 };
 

--- a/frontend/src/tests/components/Nav/Footer.test.js
+++ b/frontend/src/tests/components/Nav/Footer.test.js
@@ -1,15 +1,19 @@
 import { render, screen } from "@testing-library/react";
 import Footer from "main/components/Nav/Footer";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 describe("Footer tests", () => {
     test("renders correctly", async () => {
         render(
-            <Footer />
+            <Footer systemInfo={systemInfoFixtures.showingBoth}/>
         );
 
         const text = screen.getByTestId("footer-content");
         expect(text).toBeInTheDocument();
         expect(typeof(text.textContent)).toBe('string');
         expect(text.textContent).toEqual('HappierCows is a project of Mattanjah de Vries, Distinguished Professor of Chemistry at UC Santa Barbara. The open source code is available on GitHub.');
+    
+        const href = screen.getByTestId("github-href");
+        expect(href).toHaveAttribute("href", "https://github.com/ucsb-cs156-f22/f22-5pm-happycows");
     });
 });


### PR DESCRIPTION
There is a link to the Github page of the project. This PR changes the link from https://github.com/ucsb-cs156-s22/s22-6pm-happycows to systemInfo.sourceRepo (Note: systemInfo is pulled from the backend). This PR also adds the sourceRepo attribute to the systemInfo fixtures, edits the footer storybook so that it uses the systemInfo fixtures, and updated the footer tests to test that the Github link exists and that it links to the URL passed in via the systemInfo fixture.

Storybook Screenshot of the Footer:
![image](https://user-images.githubusercontent.com/10468001/202333162-be3e3973-e670-4caf-aa7c-a74346029ba6.png)
Docs-QA link: https://ucsb-cs156-f22.github.io/f22-5pm-happycows-docs-qa/storybook-qa/Josiah-FooterGithubLink/?path=/story/layouts-basiclayout-footer--default

To test see that the footer Github link, links to this repository (https://github.com/ucsb-cs156-f22/f22-5pm-happycows).

Closes #1