### PR TITLE
cw - Add placeholder for jobs to update cow health and produce "instructor report"

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -66,7 +66,7 @@ public class JobsController extends ApiController {
 
     @ApiOperation(value = "Launch Job to Milk the Cows")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @GetMapping("/launch/testjob")
+    @POSTMapping("/launch/testjob")
     public Job jobMilkCows() 
     {
         return jobService.runAsJob(ctx -> {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -66,7 +66,7 @@ public class JobsController extends ApiController {
 
     @ApiOperation(value = "Launch Job to Milk the Cows")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PostMapping("")
+    @PostMapping("/launch/milkcows")
     public Job jobMilkCows() 
     {
         return jobService.runAsJob(ctx -> {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -66,7 +66,7 @@ public class JobsController extends ApiController {
 
     @ApiOperation(value = "Launch Job to Milk the Cows")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @POSTMapping("/launch/testjob")
+    @PostMapping("")
     public Job jobMilkCows() 
     {
         return jobService.runAsJob(ctx -> {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -76,4 +76,28 @@ public class JobsController extends ApiController {
           });
     }
 
+    @ApiOperation(value = "Launch Job to Update Cow Health")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/launch/updatecowhealth")
+    public Job updateCowHealth(
+    ) { 
+        return jobService.runAsJob(ctx -> {
+            ctx.log("Updating cow health");
+            ctx.log("This is where the code to update the cow health will go.");
+            ctx.log("Cow health has been updated!");
+          });
+    }
+
+    @ApiOperation(value = "Launch Job to Produce Instructor Report")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/launch/instructorreport")
+    public Job instructorReport(
+    ) { 
+        return jobService.runAsJob(ctx -> {
+            ctx.log("Producing instructor report");
+            ctx.log("This is where the code to producing instructor report will go.");
+            ctx.log("Instructor report has been produced!");
+          });
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -64,4 +64,16 @@ public class JobsController extends ApiController {
           });
     }
 
+    @ApiOperation(value = "Launch Job to Milk the Cows")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/launch/testjob")
+    public Job jobMilkCows() 
+    {
+        return jobService.runAsJob(ctx -> {
+            ctx.log("Starting to milk the cows");
+            ctx.log("This is where the code to milk the cows will go.");
+            ctx.log("Cows have been milked!");
+          });
+    }
+
 }


### PR DESCRIPTION
In this PR, we added more placeholder jobs in the jobs controller for updating cow health and for producing instructor reports. When running on localhost or on heroku, when accessing the swagger-ui, should check that the PostMapping APIs show up for both update cow health and produce instructor report. 
Doing so should produce the results shown below: 
![image](https://user-images.githubusercontent.com/78510771/202599276-74f1a7ad-5ac2-446b-869e-872914e1fe48.png)
Trying and executing the APi should produce this:
![image](https://user-images.githubusercontent.com/78510771/202599558-8e0a8f46-4378-4a22-9e13-5d826945d458.png)

