### PR TITLE
pc - update CI/CD 34 (Stryker) to only run when frontend changes

### DIFF
--- a/.github/workflows/34-frontend-mutation-testing.yml
+++ b/.github/workflows/34-frontend-mutation-testing.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - main
-
+      - paths: ['frontend/**']
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In this PR, we change job 34 to only run when files in the `frontend` directory change.

This should speed up the CI/CD runs for backend only changes.