### PR TITLE
lg - change background visibility

### DIFF
--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -2,11 +2,11 @@ import React from "react";
 import { useTable, useSortBy } from 'react-table'
 import { Table, Button } from "react-bootstrap";
 import Plaintext from "main/components/Utils/Plaintext";
-
+// Stryker disable all
 var tableStyle = {
   "background": "white"
 };
-
+// Stryker enable all
 export default function OurTable({ columns, data, testid = "testid", ...rest }) {
 
   const {

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -3,6 +3,10 @@ import { useTable, useSortBy } from 'react-table'
 import { Table, Button } from "react-bootstrap";
 import Plaintext from "main/components/Utils/Plaintext";
 
+var tableStyle = {
+  "backround": "white"
+};
+
 export default function OurTable({ columns, data, testid = "testid", ...rest }) {
 
   const {
@@ -20,7 +24,7 @@ export default function OurTable({ columns, data, testid = "testid", ...rest }) 
   }, useSortBy)
 
   return (
-    <Table {...getTableProps()} striped bordered hover >
+    <Table style={tableStyle} {...getTableProps()} striped bordered hover >
       <thead>
         {headerGroups.map(headerGroup => (
           <tr {...headerGroup.getHeaderGroupProps()}>

--- a/frontend/src/main/components/OurTable.js
+++ b/frontend/src/main/components/OurTable.js
@@ -4,7 +4,7 @@ import { Table, Button } from "react-bootstrap";
 import Plaintext from "main/components/Utils/Plaintext";
 
 var tableStyle = {
-  "backround": "white"
+  "background": "white"
 };
 
 export default function OurTable({ columns, data, testid = "testid", ...rest }) {

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -48,7 +48,7 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
+    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, opacity: 0.6 }}>
         <BasicLayout>
             <div className="pt-2">
                 <h1>Leaderboard</h1>

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -48,7 +48,7 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{backgroundSize: 'cover', backgroundImage: `url(${Background})`, opacity: 0.8}}>
+    <div style={{backgroundSize: 'cover', backgroundImage: `url(${Background})`}}>
         <BasicLayout>
             <div className="pt-2">
                 <h1>Leaderboard</h1>

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -46,19 +46,21 @@ export default function LeaderboardPage() {
     );
   // Stryker enable all 
 
-  <div test={{backgroundSize: 'cover', backgroundImage: `url(${Background})`, opacity: 0.75}}></div>
+ //<div test={{backgroundSize: 'cover', backgroundImage: `url(${Background})`, opacity: 0.75}}></div>
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{test}}>
+    <div style={{backgroundSize: 'cover', backgroundImage: `url(${Background})`, opacity: 0.75}}>
         <BasicLayout>
             <div className="pt-2">
+              <div style={{opactiy: 1.00}}>
                 <h1>Leaderboard</h1>
                 {
                   showLeaderboard?
                   (<LeaderboardTable leaderboardUsers={userCommons} currentUser={currentUser} />) :
                   (<p>You're not authorized to see the leaderboard.</p>)
                 }
+                </div>
             </div>
         </BasicLayout>
     </div>

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -50,7 +50,7 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{backgroundSize: 'cover', backgroundImage: `url(${Background})`, opacity: 0.75}}>
+    <div style={{backgroundSize: 'cover', backgroundImage: `url(${Background})`, opacity: 0.8}}>
         <BasicLayout>
             <div className="pt-2">
               <div style={{opactiy: 1.00}}>

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -46,14 +46,11 @@ export default function LeaderboardPage() {
     );
   // Stryker enable all 
 
- //<div test={{backgroundSize: 'cover', backgroundImage: `url(${Background})`, opacity: 0.75}}></div>
-
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
     <div style={{backgroundSize: 'cover', backgroundImage: `url(${Background})`, opacity: 0.8}}>
         <BasicLayout>
             <div className="pt-2">
-              <div style={{opactiy: 1.00}}>
                 <h1>Leaderboard</h1>
                 {
                   showLeaderboard?
@@ -61,7 +58,6 @@ export default function LeaderboardPage() {
                   (<p>You're not authorized to see the leaderboard.</p>)
                 }
                 </div>
-            </div>
         </BasicLayout>
     </div>
   )

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -46,9 +46,11 @@ export default function LeaderboardPage() {
     );
   // Stryker enable all 
 
+  <div test={{backgroundSize: 'cover', backgroundImage: `url(${Background})`, opacity: 0.75}}></div>
+
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})`, opacity: 0.6 }}>
+    <div style={{ backgroundSize: 'cover', backgroundImage: test}}>
         <BasicLayout>
             <div className="pt-2">
                 <h1>Leaderboard</h1>

--- a/frontend/src/main/pages/LeaderboardPage.js
+++ b/frontend/src/main/pages/LeaderboardPage.js
@@ -50,7 +50,7 @@ export default function LeaderboardPage() {
 
   const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commons.showLeaderboard );
   return (
-    <div style={{ backgroundSize: 'cover', backgroundImage: test}}>
+    <div style={{test}}>
         <BasicLayout>
             <div className="pt-2">
                 <h1>Leaderboard</h1>


### PR DESCRIPTION
In this pull request, the OurTable was changed so that any and all pages that use a table will have a white background. This is to avoid any issues with the background image making the table difficult to read. 

This was done with the same approach as team f22-7pm-happycows as they solved this issue previously.

<img width="1234" alt="image" src="https://user-images.githubusercontent.com/91626968/204202920-4ecee583-c78b-4970-8d3a-a897eae05cc4.png">
