### PR TITLE
ak - adding pc's changes from 6pm happycows

### DIFF
--- a/frontend/src/fixtures/commonsPlusFixtures.js
+++ b/frontend/src/fixtures/commonsPlusFixtures.js
@@ -1,0 +1,72 @@
+const commonsPlusFixtures = {
+    threeCommonsPlus: [
+        {
+            "commons": {
+                "id": 1,
+                "name": "com",
+                "cowPrice": 1.0,
+                "milkPrice": 1.0,
+                "startingBalance": 10.0,
+                "startingDate": "2022-11-22T00:00:00",
+                "endingDate": null,
+                "degradationRate": 0.01,
+                "showLeaderboard": false
+            },
+            "totalCows": 10,
+            "totalUsers": 2
+        },
+        {
+            "commons":
+            {
+                "id": 2,
+                "name": "Com2",
+                "cowPrice": 1.0,
+                "milkPrice": 1.0,
+                "startingBalance": 10.0,
+                "startingDate": "2022-11-22T00:00:00",
+                "endingDate": null,
+                "degradationRate": 0.01,
+                "showLeaderboard": true
+            },
+            "totalCows": 0,
+            "totalUsers": 1
+        },
+        {
+            "commons":
+            {
+                "id": 3,
+                "name": "Not DLG",
+                "cowPrice": 10.0,
+                "milkPrice": 3.0,
+                "startingBalance": 74.0,
+                "startingDate": "2022-11-26T00:00:00",
+                "endingDate": null,
+                "degradationRate": 5.0,
+                "showLeaderboard": true
+            },
+            "totalCows": 0,
+            "totalUsers": 1
+        },
+
+    ],
+    oneCommonsPlus: [
+        {
+            "commons":
+            {
+                "id": 4,
+                "name": "Test",
+                "cowPrice": 10.0,
+                "milkPrice": 1.0,
+                "startingBalance": 100.0,
+                "startingDate": "2022-11-11T00:00:00",
+                "endingDate": null,
+                "degradationRate": 3.0,
+                "showLeaderboard": false
+            },
+            "totalCows": 0,
+            "totalUsers": 0
+        }
+    ]
+}
+
+export default commonsPlusFixtures;

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -10,7 +10,7 @@ export default function CommonsTable({ commons, currentUser }) {
     const navigate = useNavigate();
 
     const editCallback = (cell) => {
-        navigate(`/admin/editcommons/${cell.row.values.id}`)
+        navigate(`/admin/editcommons/${cell.row.values["commons.id"]}`)
     }
 
     // Stryker disable all : hard to test for query caching
@@ -22,51 +22,54 @@ export default function CommonsTable({ commons, currentUser }) {
     // Stryker enable all
 
     // Stryker disable next-line all : TODO try to make a good test for this
-    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+    const deleteCallback = async (cell) => { 
+        console.log("deleteCallback cell=", cell);
+        deleteMutation.mutate(cell); 
+    }
 
     const leaderboardCallback = (cell) => {
-        navigate(`/leaderboard/${cell.row.values.id}`)
+        navigate(`/leaderboard/${cell.row.values["commons.id"]}`)
     }
 
     const columns = [
         {
             Header: 'id',
-            accessor: 'id', // accessor is the "key" in the data
+            accessor: 'commons.id', // accessor is the "key" in the data
 
         },
         {
             Header:'Name',
-            accessor: 'name',
+            accessor: 'commons.name',
         },
         {
             Header:'Cow Price',
-            accessor: row => row.cowPrice,
-            id: 'cowPrice'
+            accessor: row => row.commons.cowPrice,
+            id: 'commons.cowPrice'
         },
         {
             Header:'Milk Price',
-            accessor: row => row.milkPrice,
-            id: 'milkPrice'
+            accessor: row => row.commons.milkPrice,
+            id: 'commons.milkPrice'
         },
         {
             Header:'Starting Balance',
-            accessor: row => row.startingBalance,
-            id: 'startingBalance'
+            accessor: row => row.commons.startingBalance,
+            id: 'commons.startingBalance'
         },
         {
             Header:'Starting Date',
-            accessor: row => String(row.startingDate).slice(0,10),
-            id: 'startingDate'
+            accessor: row => String(row.commons.startingDate).slice(0,10),
+            id: 'commons.startingDate'
         },
         {
             Header:'Degradation Rate',
-            accessor: row => row.degradationRate,
-            id: 'degradationRate'
+            accessor: row => row.commons.degradationRate,
+            id: 'commons.degradationRate'
         },
         {
             Header:'Show Leaderboard?',
-            id: 'showLeaderboard', // needed for tests
-            accessor: (row, _rowIndex) => String(row.showLeaderboard) // hack needed for boolean values to show up
+            id: 'commons.showLeaderboard', // needed for tests
+            accessor: (row, _rowIndex) => String(row.commons.showLeaderboard) // hack needed for boolean values to show up
         },
         {
             Header: 'Cows',
@@ -78,12 +81,16 @@ export default function CommonsTable({ commons, currentUser }) {
 
     const columnsIfAdmin = [
         ...columns,
-        ButtonColumn("Edit", "primary", editCallback, testid),
-        ButtonColumn("Delete", "danger", deleteCallback, testid),
-        ButtonColumn("Leaderboard", "secondary", leaderboardCallback, testid)
+        ButtonColumn("Edit",
+"primary", editCallback, testid),
+        ButtonColumn("Delete",
+"danger", deleteCallback, testid),
+        ButtonColumn("Leaderboard",
+"secondary", leaderboardCallback, testid)
     ];
 
-    const columnsToDisplay = hasRole(currentUser, "ROLE_ADMIN") ? columnsIfAdmin : columns;
+    const columnsToDisplay = hasRole(currentUser,
+"ROLE_ADMIN") ? columnsIfAdmin : columns;
 
     return <OurTable
         data={commons}

--- a/frontend/src/main/utils/commonsUtils.js
+++ b/frontend/src/main/utils/commonsUtils.js
@@ -10,7 +10,7 @@ export function cellToAxiosParamsDelete(cell) {
         url: "/api/commons",
         method: "DELETE",
         params: {
-            id: cell.row.values.id
+            id: cell.row.values["commons.id"]
         }
     }
 }

--- a/frontend/src/tests/components/Commons/CommonsTable.test.js
+++ b/frontend/src/tests/components/Commons/CommonsTable.test.js
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import CommonsTable from "main/components/Commons/CommonsTable"
 import { currentUserFixtures } from "fixtures/currentUserFixtures";
-import commonsFixtures from "fixtures/commonsFixtures";
+import commonsPlusFixtures from "fixtures/commonsPlusFixtures";
 
 const mockedNavigate = jest.fn();
 
@@ -59,7 +59,7 @@ describe("UserTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <CommonsTable commons={commonsFixtures.threeCommons} currentUser={currentUser} />
+          <CommonsTable commons={commonsPlusFixtures.threeCommonsPlus} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -75,11 +75,11 @@ describe("UserTable tests", () => {
     });
 
     expectedFields.forEach((field) => {
-      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-commons.${field}`);
       expect(header).toBeInTheDocument();
     });
 
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("5");
-    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("4");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-commons.id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.id`)).toHaveTextContent("2");
   });
 });

--- a/frontend/src/tests/pages/AdminListCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminListCommonsPage.test.js
@@ -6,7 +6,7 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 import AdminListCommonPage from "main/pages/AdminListCommonPage";
-import commonsFixtures from "fixtures/commonsFixtures";
+import commonsPlusFixtures from "fixtures/commonsPlusFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
@@ -77,7 +77,7 @@ describe("AdminListCommonPage tests", () => {
     test("renders three commons without crashing for admin user", async () => {
         setupAdminUser();
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/commons/allplus").reply(200, commonsFixtures.threeCommons);
+        axiosMock.onGet("/api/commons/allplus").reply(200, commonsPlusFixtures.threeCommonsPlus);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -87,9 +87,9 @@ describe("AdminListCommonPage tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("5");
-        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("4");
-        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("1");
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-commons.id`)).toHaveTextContent("1");
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-commons.id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-commons.id`)).toHaveTextContent("3");
     });
 
     test("renders empty table when backend unavailable, user only", async () => {
@@ -111,15 +111,15 @@ describe("AdminListCommonPage tests", () => {
         await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
         restoreConsole();
 
-        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-commons.id`)).not.toBeInTheDocument();
     });
 
     test("what happens when you click delete, admin", async () => {
         setupAdminUser();
 
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/commons/allplus").reply(200, commonsFixtures.threeCommons);
-        axiosMock.onDelete("/api/commons", {params: {id: 5}}).reply(200, "Commons with id 5 was deleted");
+        axiosMock.onGet("/api/commons/allplus").reply(200, commonsPlusFixtures.threeCommonsPlus);
+        axiosMock.onDelete("/api/commons", {params: {id: 1}}).reply(200, "Commons with id 1 was deleted");
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -129,22 +129,22 @@ describe("AdminListCommonPage tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument();
-        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("5"); 
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-commons.id`)).toBeInTheDocument();
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-commons.id`)).toHaveTextContent("1"); 
 
         const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
         expect(deleteButton).toBeInTheDocument();
        
         fireEvent.click(deleteButton);
 
-        await waitFor(() => { expect(mockToast).toBeCalledWith("Commons with id 5 was deleted") });
+        await waitFor(() => { expect(mockToast).toBeCalledWith("Commons with id 1 was deleted") });
     });
 
     test("what happens when you click edit as an admin", async () => {
         setupAdminUser();
 
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/commons/allplus").reply(200, commonsFixtures.threeCommons);
+        axiosMock.onGet("/api/commons/allplus").reply(200, commonsPlusFixtures.threeCommonsPlus);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -154,21 +154,21 @@ describe("AdminListCommonPage tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("5");
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-commons.id`)).toHaveTextContent("1");
       
         const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
         expect(editButton).toBeInTheDocument();
 
         fireEvent.click(editButton);
 
-        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/admin/editcommons/5'));
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/admin/editcommons/1'));
     });
 
     test("what happens when you click leaderboard as an admin", async () => {
         setupAdminUser();
 
         const queryClient = new QueryClient();
-        axiosMock.onGet("/api/commons/allplus").reply(200, commonsFixtures.threeCommons);
+        axiosMock.onGet("/api/commons/allplus").reply(200, commonsPlusFixtures.threeCommonsPlus);
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -178,13 +178,13 @@ describe("AdminListCommonPage tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("5");
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-commons.id`)).toHaveTextContent("1");
       
         const leaderboardButton = screen.getByTestId(`${testId}-cell-row-0-col-Leaderboard-button`);
         expect(leaderboardButton).toBeInTheDocument();
 
         fireEvent.click(leaderboardButton);
 
-        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/leaderboard/5'));
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/leaderboard/1'));
     })
 });

--- a/frontend/src/tests/utils/commonsUtil.test.js
+++ b/frontend/src/tests/utils/commonsUtil.test.js
@@ -33,7 +33,7 @@ describe("CommonsUtils", () => {
     describe("cellToAxiosParamsDelete", () => {
         test("It returns the correct params", () => {
             // arrange
-            const cell = { row: { values: { id: 17 } } };
+            const cell = { row: { values: { "commons.id" : 17 } } };
 
             // act
             const result = cellToAxiosParamsDelete(cell);


### PR DESCRIPTION
From https://github.com/ucsb-cs156-f22/f22-6pm-happycows/pull/37:
In this PR, we fix the CommonsTable so that it correctly pulls information from the /allplus endpoint.

When the endpoint was changed from /all to /allplus, the shape of the JSON changed, but the CommonsTable wasn't updated. This PR fixes that.

We go from (screenshot from the [f22-5pm heroku site](https://f22-5pm-3-happycows.herokuapp.com/)):
<img width="1512" alt="Screenshot 2022-11-27 at 8 00 53 PM (1)" src="https://user-images.githubusercontent.com/41317321/204206308-f3b7b399-be31-43f3-8b00-42fdaf5d80cd.png">

To (screenshot from localhost, so different commons):
<img width="1512" alt="Screenshot 2022-11-27 at 10 14 16 PM" src="https://user-images.githubusercontent.com/41317321/204206622-f63b7dd1-5a4a-4f5c-920a-e6c12f8f5fba.png">