### PR TITLE
cs - join commons column

### DIFF
--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -55,7 +55,7 @@ export default function HomePage() {
         <Container>
           <Row>
             <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} /></Col>
-            <Col sm><CommonsList commonList={commons} title="Join A Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
+            <Col sm><CommonsList commonList={commons} title="Join A New Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
           </Row>
         </Container>
       </BasicLayout>

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -48,6 +48,14 @@ export default function HomePage() {
   let navigate = useNavigate();
   const visitButtonClick = (id) => { navigate("/play/" + id) };
 
+  //create a list of commons that the user hasn't joined for use in the "Join a New Commons" list.
+  let joinedIdList = [];
+  for (let commonJoined of commonsJoined) {
+	joinedIdList.push(commonJoined.id)
+  }
+  let commonsNotJoined = commons.filter(f => !joinedIdList.includes(f.id));
+
+
   return (
     <div style={{ backgroundSize: 'cover', backgroundImage: `url(${Background})` }}>
       <BasicLayout>
@@ -55,7 +63,7 @@ export default function HomePage() {
         <Container>
           <Row>
             <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} /></Col>
-            <Col sm><CommonsList commonList={commons} title="Join A New Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
+            <Col sm><CommonsList commonList={commonsNotJoined} title="Join A New Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
           </Row>
         </Container>
       </BasicLayout>

--- a/frontend/src/tests/components/Commons/CommonsList.test.js
+++ b/frontend/src/tests/components/Commons/CommonsList.test.js
@@ -5,13 +5,13 @@ import commonsFixtures from "fixtures/commonsFixtures";
 describe("CommonsList tests", () => {
     test("renders without crashing when button text is set", () => {
         render(
-            <CommonsList commonList = {commonsFixtures.threeCommons} buttonText = {"Join"} title="Join A Commons"/>
+            <CommonsList commonList = {commonsFixtures.threeCommons} buttonText = {"Join"} title="Join A New Commons"/>
         );
 
         const title = screen.getByTestId("commonsList-title");
         expect(title).toBeInTheDocument();
         expect(typeof(title.textContent)).toBe('string');
-        expect(title.textContent).toEqual('Join A Commons');
+        expect(title.textContent).toEqual('Join A New Commons');
 
         const subtitle_name = screen.getByTestId("commonsList-subtitle-name");
         expect(subtitle_name).toBeInTheDocument();

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -85,8 +85,8 @@ describe("HomePage tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByTestId("commonsCard-button-Join-1")).toBeInTheDocument();
-        const joinButton = screen.getByTestId("commonsCard-button-Join-1");
+        expect(await screen.findByTestId("commonsCard-button-Join-4")).toBeInTheDocument();
+        const joinButton = screen.getByTestId("commonsCard-button-Join-4");
         fireEvent.click(joinButton);
     });
 });


### PR DESCRIPTION
In this PR, I changed the functionality of the "Join a New Commons" list on the homepage so that it only lists commons the user hasn't joined. So now when the user joins a new commons, it moves into the the other list, as seen the screenshots below:

No commons joined:
![image](https://user-images.githubusercontent.com/39968382/204397014-b050d58b-4a13-4a0e-a3f1-2e53d72fbe88.png)

Joined 1
![image](https://user-images.githubusercontent.com/39968382/204397081-9285030f-047b-473e-888b-c82b91109a95.png)

Joined 3
![image](https://user-images.githubusercontent.com/39968382/204397141-0cd5af5e-9ac2-4ebd-8622-1ed2bde11fed.png)

Joined 2
![image](https://user-images.githubusercontent.com/39968382/204397179-d4ff30e0-b8b9-4dd8-8f33-1f3ecb94f6d1.png)


Closes #27 