### PR TITLE
Added Carrying Capacity to Commons

### DIFF
--- a/frontend/src/fixtures/commonsFixtures.js
+++ b/frontend/src/fixtures/commonsFixtures.js
@@ -12,6 +12,7 @@ const commonsFixtures = {
             "milkPrice": 10,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         },
         {
             "id": 4,
@@ -25,6 +26,7 @@ const commonsFixtures = {
             "milkPrice": 10,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 123,
         },
         {
             "id": 1,
@@ -38,6 +40,7 @@ const commonsFixtures = {
             "milkPrice": 10,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 42,
         }
     ],
     oneCommons:
@@ -54,6 +57,7 @@ const commonsFixtures = {
                 "milkPrice": 10,
                 "degradationRate": .5,
                 "showLeaderboard": true,
+                "carryingCapacity": 314,
             }
         ],
 
@@ -67,6 +71,7 @@ const commonsFixtures = {
             "cowPrice": 15,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         },
         {
             "id": 8,
@@ -77,6 +82,7 @@ const commonsFixtures = {
             "cowPrice": 15,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         },
         {
             "id": 6,
@@ -87,6 +93,7 @@ const commonsFixtures = {
             "cowPrice": 15,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         },
         {
             "id": 5,
@@ -97,6 +104,7 @@ const commonsFixtures = {
             "cowPrice": 15,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         },
         {
             "id": 4,
@@ -107,6 +115,7 @@ const commonsFixtures = {
             "cowPrice": 15,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         },
         {
             "id": 3,
@@ -117,6 +126,7 @@ const commonsFixtures = {
             "cowPrice": 15,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         },
         {
             "id": 2,
@@ -127,6 +137,7 @@ const commonsFixtures = {
             "cowPrice": 15,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         }
     ],
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -113,6 +113,7 @@ public class CommonsController extends ApiController {
     updated.setEndingDate(params.getEndingDate());
     updated.setShowLeaderboard(params.getShowLeaderboard());
     updated.setDegradationRate(params.getDegradationRate());
+    updated.setCarryingCapacity(params.getCarryingCapacity());
 
     if (params.getDegradationRate() < 0) {
       throw new IllegalArgumentException("Degradation Rate cannot be negative");
@@ -150,6 +151,7 @@ public class CommonsController extends ApiController {
         .endingDate(params.getEndingDate())
         .degradationRate(params.getDegradationRate())
         .showLeaderboard(params.getShowLeaderboard())
+        .carryingCapacity(params.getCarryingCapacity())
         .build();
 
     // throw exception for degradation rate

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -32,6 +32,7 @@ public class Commons
   private LocalDateTime endingDate;
   private double degradationRate;
   private boolean showLeaderboard;
+  private int carryingCapacity;
 
   @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
   @JoinTable(name = "user_commons",

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -35,4 +35,6 @@ public class CreateCommonsParams {
   private LocalDateTime endingDate;
   @Builder.Default
   private Boolean showLeaderboard = false; 
+  @NumberFormat
+  private int carryingCapacity;
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -76,6 +76,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .endingDate(someOtherTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -87,6 +88,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .endingDate(someOtherTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -124,6 +126,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .degradationRate(0)
         .endingDate(someOtherTime)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -135,6 +138,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .degradationRate(0)
         .endingDate(someOtherTime)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -169,6 +173,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingBalance(1020.10)
         .startingDate(someTime)
         .degradationRate(-8.49)
+        .carryingCapacity(100)
         .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -178,6 +183,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingBalance(1020.10)
         .startingDate(someTime)
         .degradationRate(-8.49)
+        .carryingCapacity(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -233,6 +239,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .endingDate(someOtherTime)
         .degradationRate(50.0)
         .showLeaderboard(true)
+        .carryingCapacity(100)
         .build();
 
     Commons commons = Commons.builder()
@@ -244,6 +251,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .endingDate(someOtherTime)
         .degradationRate(50.0)
         .showLeaderboard(true)
+        .carryingCapacity(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -266,6 +274,8 @@ public class CommonsControllerTests extends ControllerTestCase {
     commons.setDegradationRate(parameters.getDegradationRate());
     parameters.setShowLeaderboard(false);
     commons.setShowLeaderboard(parameters.getShowLeaderboard());
+    parameters.setCarryingCapacity(123);
+    commons.setCarryingCapacity(parameters.getCarryingCapacity());
 
     requestBody = objectMapper.writeValueAsString(parameters);
 
@@ -300,6 +310,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .degradationRate(8.49)
         .endingDate(someOtherTime)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     Commons commons = Commons.builder()
@@ -311,6 +322,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .degradationRate(8.49)
         .endingDate(someOtherTime)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -331,6 +343,8 @@ public class CommonsControllerTests extends ControllerTestCase {
     commons.setMilkPrice(parameters.getMilkPrice());
     parameters.setDegradationRate(0);
     commons.setDegradationRate(parameters.getDegradationRate());
+    parameters.setCarryingCapacity(123);
+    commons.setCarryingCapacity(parameters.getCarryingCapacity());
 
     requestBody = objectMapper.writeValueAsString(parameters);
 
@@ -363,6 +377,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingDate(someTime)
         .degradationRate(8.49)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     Commons commons = Commons.builder()
@@ -373,6 +388,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingDate(someTime)
         .degradationRate(8.49)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -617,6 +633,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .endingDate(someOtherTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));


### PR DESCRIPTION
Closes #37 

- [X] Add carryingCapacity to the `Commons` entity
- [X] Add it to the CRUD operations for creating Commons
- [X] Add tests that cover the carryingCapacity field
- [X] Add it to the fixtures for commons

To test add a commons with swagger with some carryingCapacity. Get the commons to make sure it got added properly. Update the commons's carryingCapcaity and get the commons to make sure it got updated properly.