### PR TITLE
Josiah - Adds Carrying Capacity to Commons Table

### DIFF
--- a/frontend/src/fixtures/commonsFixtures.js
+++ b/frontend/src/fixtures/commonsFixtures.js
@@ -12,6 +12,7 @@ const commonsFixtures = {
             "milkPrice": 10,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         },
         {
             "id": 4,
@@ -25,6 +26,7 @@ const commonsFixtures = {
             "milkPrice": 10,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 123,
         },
         {
             "id": 1,
@@ -38,6 +40,7 @@ const commonsFixtures = {
             "milkPrice": 10,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 42,
         }
     ],
     oneCommons:
@@ -54,6 +57,7 @@ const commonsFixtures = {
                 "milkPrice": 10,
                 "degradationRate": .5,
                 "showLeaderboard": true,
+                "carryingCapacity": 314,
             }
         ],
 
@@ -67,6 +71,7 @@ const commonsFixtures = {
             "cowPrice": 15,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         },
         {
             "id": 8,
@@ -77,6 +82,7 @@ const commonsFixtures = {
             "cowPrice": 15,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         },
         {
             "id": 6,
@@ -87,6 +93,7 @@ const commonsFixtures = {
             "cowPrice": 15,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         },
         {
             "id": 5,
@@ -97,6 +104,7 @@ const commonsFixtures = {
             "cowPrice": 15,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         },
         {
             "id": 4,
@@ -107,6 +115,7 @@ const commonsFixtures = {
             "cowPrice": 15,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         },
         {
             "id": 3,
@@ -117,6 +126,7 @@ const commonsFixtures = {
             "cowPrice": 15,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         },
         {
             "id": 2,
@@ -127,6 +137,7 @@ const commonsFixtures = {
             "cowPrice": 15,
             "degradationRate": .5,
             "showLeaderboard": true,
+            "carryingCapacity": 100,
         }
     ],
 }

--- a/frontend/src/fixtures/commonsPlusFixtures.js
+++ b/frontend/src/fixtures/commonsPlusFixtures.js
@@ -10,7 +10,8 @@ const commonsPlusFixtures = {
                 "startingDate": "2022-11-22T00:00:00",
                 "endingDate": null,
                 "degradationRate": 0.01,
-                "showLeaderboard": false
+                "showLeaderboard": false,
+                "carryingCapacity": 100,
             },
             "totalCows": 10,
             "totalUsers": 2
@@ -26,7 +27,8 @@ const commonsPlusFixtures = {
                 "startingDate": "2022-11-22T00:00:00",
                 "endingDate": null,
                 "degradationRate": 0.01,
-                "showLeaderboard": true
+                "showLeaderboard": true,
+                "carryingCapacity": 42,
             },
             "totalCows": 0,
             "totalUsers": 1
@@ -42,7 +44,8 @@ const commonsPlusFixtures = {
                 "startingDate": "2022-11-26T00:00:00",
                 "endingDate": null,
                 "degradationRate": 5.0,
-                "showLeaderboard": true
+                "showLeaderboard": true,
+                "carryingCapacity": 123,
             },
             "totalCows": 0,
             "totalUsers": 1
@@ -61,7 +64,8 @@ const commonsPlusFixtures = {
                 "startingDate": "2022-11-11T00:00:00",
                 "endingDate": null,
                 "degradationRate": 3.0,
-                "showLeaderboard": false
+                "showLeaderboard": false,
+                "carryingCapacity": 23,
             },
             "totalCows": 0,
             "totalUsers": 0

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -74,6 +74,11 @@ export default function CommonsTable({ commons, currentUser }) {
         {
             Header: 'Cows',
             accessor: 'totalCows'
+        },
+        {
+            Header: 'Carrying Capacity',
+            accessor: row => row.commons.carryingCapacity,
+            id: 'commons.carryingCapacity'
         }
     ];
 

--- a/frontend/src/stories/components/Commons/CommonsTable.stories.js
+++ b/frontend/src/stories/components/Commons/CommonsTable.stories.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import CommonsTable from "main/components/Commons/CommonsTable";
-import commonsFixtures from 'fixtures/commonsFixtures';
+import commonsPlusFixtures from 'fixtures/commonsPlusFixtures';
 import { currentUserFixtures } from 'fixtures/currentUserFixtures';
 
 export default {
@@ -24,26 +24,26 @@ Empty.args = {
 export const ThreeCommons = Template.bind({});
 
 ThreeCommons.args = {
-    commons: commonsFixtures.threeCommons
+    commons: commonsPlusFixtures.threeCommonsPlus
 };
 
 export const OneCommons = Template.bind({});
 
 OneCommons.args = {
-    commons: commonsFixtures.oneCommons
+    commons: commonsPlusFixtures.oneCommonsPlus
 }
 
 export const ThreeCommonsAdmin = Template.bind({});
 
 ThreeCommonsAdmin.args = {
-    commons: commonsFixtures.threeCommons,
+    commons: commonsPlusFixtures.threeCommonsPlus,
     currentUser: currentUserFixtures.adminUser
 };
 
 export const OneCommonsAdmin = Template.bind({});
 
 OneCommonsAdmin.args = {
-    commons: commonsFixtures.oneCommons,
+    commons: commonsPlusFixtures.oneCommonsPlus,
     currentUser: currentUserFixtures.adminUser
 }
 

--- a/frontend/src/tests/components/Commons/CommonsTable.test.js
+++ b/frontend/src/tests/components/Commons/CommonsTable.test.js
@@ -66,7 +66,7 @@ describe("UserTable tests", () => {
     );
 
     const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date', 'Degradation Rate', 'Carrying Capacity'];
-    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate", "carryingCapacity"];
+    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate", "degradationRate", "carryingCapacity"];
     const testId = "CommonsTable";
 
     expectedHeaders.forEach((headerText) => {

--- a/frontend/src/tests/components/Commons/CommonsTable.test.js
+++ b/frontend/src/tests/components/Commons/CommonsTable.test.js
@@ -65,8 +65,8 @@ describe("UserTable tests", () => {
 
     );
 
-    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date', 'Degradation Rate'];
-    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate", "degradationRate"];
+    const expectedHeaders = ["id", "Name", "Cow Price", 'Milk Price', 'Starting Balance', 'Starting Date', 'Degradation Rate', 'Carrying Capacity'];
+    const expectedFields = ["id", "name", "cowPrice", "milkPrice", "startingBalance", "startingDate", "carryingCapacity"];
     const testId = "CommonsTable";
 
     expectedHeaders.forEach((headerText) => {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -113,6 +113,7 @@ public class CommonsController extends ApiController {
     updated.setEndingDate(params.getEndingDate());
     updated.setShowLeaderboard(params.getShowLeaderboard());
     updated.setDegradationRate(params.getDegradationRate());
+    updated.setCarryingCapacity(params.getCarryingCapacity());
 
     if (params.getDegradationRate() < 0) {
       throw new IllegalArgumentException("Degradation Rate cannot be negative");
@@ -150,6 +151,7 @@ public class CommonsController extends ApiController {
         .endingDate(params.getEndingDate())
         .degradationRate(params.getDegradationRate())
         .showLeaderboard(params.getShowLeaderboard())
+        .carryingCapacity(params.getCarryingCapacity())
         .build();
 
     // throw exception for degradation rate

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Commons.java
@@ -32,6 +32,7 @@ public class Commons
   private LocalDateTime endingDate;
   private double degradationRate;
   private boolean showLeaderboard;
+  private int carryingCapacity;
 
   @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
   @JoinTable(name = "user_commons",

--- a/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/models/CreateCommonsParams.java
@@ -35,4 +35,6 @@ public class CreateCommonsParams {
   private LocalDateTime endingDate;
   @Builder.Default
   private Boolean showLeaderboard = false; 
+  @NumberFormat
+  private int carryingCapacity;
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CommonsControllerTests.java
@@ -76,6 +76,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .endingDate(someOtherTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -87,6 +88,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .endingDate(someOtherTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -124,6 +126,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .degradationRate(0)
         .endingDate(someOtherTime)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -135,6 +138,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .degradationRate(0)
         .endingDate(someOtherTime)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -169,6 +173,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingBalance(1020.10)
         .startingDate(someTime)
         .degradationRate(-8.49)
+        .carryingCapacity(100)
         .build();
 
     CreateCommonsParams parameters = CreateCommonsParams.builder()
@@ -178,6 +183,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingBalance(1020.10)
         .startingDate(someTime)
         .degradationRate(-8.49)
+        .carryingCapacity(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -233,6 +239,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .endingDate(someOtherTime)
         .degradationRate(50.0)
         .showLeaderboard(true)
+        .carryingCapacity(100)
         .build();
 
     Commons commons = Commons.builder()
@@ -244,6 +251,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .endingDate(someOtherTime)
         .degradationRate(50.0)
         .showLeaderboard(true)
+        .carryingCapacity(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -266,6 +274,8 @@ public class CommonsControllerTests extends ControllerTestCase {
     commons.setDegradationRate(parameters.getDegradationRate());
     parameters.setShowLeaderboard(false);
     commons.setShowLeaderboard(parameters.getShowLeaderboard());
+    parameters.setCarryingCapacity(123);
+    commons.setCarryingCapacity(parameters.getCarryingCapacity());
 
     requestBody = objectMapper.writeValueAsString(parameters);
 
@@ -300,6 +310,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .degradationRate(8.49)
         .endingDate(someOtherTime)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     Commons commons = Commons.builder()
@@ -311,6 +322,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .degradationRate(8.49)
         .endingDate(someOtherTime)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -331,6 +343,8 @@ public class CommonsControllerTests extends ControllerTestCase {
     commons.setMilkPrice(parameters.getMilkPrice());
     parameters.setDegradationRate(0);
     commons.setDegradationRate(parameters.getDegradationRate());
+    parameters.setCarryingCapacity(123);
+    commons.setCarryingCapacity(parameters.getCarryingCapacity());
 
     requestBody = objectMapper.writeValueAsString(parameters);
 
@@ -363,6 +377,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingDate(someTime)
         .degradationRate(8.49)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     Commons commons = Commons.builder()
@@ -373,6 +388,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .startingDate(someTime)
         .degradationRate(8.49)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     String requestBody = objectMapper.writeValueAsString(parameters);
@@ -617,6 +633,7 @@ public class CommonsControllerTests extends ControllerTestCase {
         .endingDate(someOtherTime)
         .degradationRate(50.0)
         .showLeaderboard(false)
+        .carryingCapacity(100)
         .build();
 
     when(commonsRepository.findById(eq(2L))).thenReturn(Optional.of(c));


### PR DESCRIPTION
Closes #62 
Note: should be merged after this PR: https://github.com/ucsb-cs156-f22/f22-5pm-happycows/pull/60 is merged
This PR adds the carrying capacity field to the commons table. The field shows up when viewing the AdminListCommonPage.
Additionally, this fixes a bug I found with the CommonsTable storybook by using the commonsPlus fixtures instead of the commons fixtures.

Before Change:
![image](https://user-images.githubusercontent.com/10468001/204686693-7de1a046-5dbe-4770-bf01-b77a83c66b0b.png)

After Change:
![image](https://user-images.githubusercontent.com/10468001/204686886-28c116e5-6c33-4da7-90a6-2c4fffde9a58.png)

Commons Table Storybook Before Change:
![image](https://user-images.githubusercontent.com/10468001/204688294-972a5d95-1267-4809-9fc5-cc251a9b576e.png)

Commons Table Storybook After Change (https://ucsb-cs156-f22.github.io/f22-5pm-happycows-docs-qa/storybook-qa/Josiah-CarryingCapacityCommonsTable/?path=/story/components-commons-commonstable--three-commons-admin):
![image](https://user-images.githubusercontent.com/10468001/204688314-ff9972fb-5b43-495f-a8c5-a8913b40d61a.png)
