### PR TITLE
cw - frontend changes to launch cow health updates

### DIFF
--- a/frontend/src/fixtures/jobsFixtures.js
+++ b/frontend/src/fixtures/jobsFixtures.js
@@ -72,6 +72,29 @@ const jobsFixtures = {
       "fail": false,
       "sleepMs": 1000
     },
+    threeUpdates: [
+      {
+        "id": 1,
+        "createdAt": "2022-11-13T19:49:58.097465-08:00",
+        "updatedAt": "2022-11-13T19:49:59.203879-08:00",
+        "status": "complete",
+        "log": "Updating cow health\nThis is where the code to update the cow health will go.\nCow health has been updated!"
+      },
+      {
+        "id": 2,
+        "createdAt": "2022-11-13T19:49:58.097465-08:00",
+        "updatedAt": "2022-11-13T19:49:59.203879-08:00",
+        "status": "running",
+        "log": "Updating cow health\nThis is where the code to update the cow health will go.\nCow health has been updated!"
+      },
+      {
+        "id":3,
+        "createdAt": "2022-11-13T19:49:58.097465-08:00",
+        "updatedAt": "2022-11-13T19:49:59.203879-08:00",
+        "status": "error",
+        "log": "Updating cow health\nThis is where the code to update the cow health will go.\nCow health has been updated!"
+      }
+    ],
 };
 
 export default jobsFixtures;

--- a/frontend/src/main/components/Jobs/UpdateCowHealthForm.js
+++ b/frontend/src/main/components/Jobs/UpdateCowHealthForm.js
@@ -1,6 +1,20 @@
-function UpdateCowHealthForm() {
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+
+function UpdateCowHealthForm( {submitAction} ) {
+
+    // Stryker disable all
+    const {
+      handleSubmit,
+    } = useForm(
+    );
+    // Stryker enable all
+
     return (
-      <p>This will be the UpdateCowHealthForm Job Function! (Creating this form asap Money!)</p>
+      <Form onSubmit={handleSubmit(submitAction)}>
+        <p>Click this button to update cows' health in all commons!</p>
+        <Button type="submit" data-testid="UpdateCowHealthForm-Submit-Button">Update</Button>
+    </Form>
     );
   }
   

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -1,3 +1,5 @@
+// adminjobspage
+
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import JobsTable from "main/components/Jobs/JobsTable";
@@ -14,7 +16,7 @@ const AdminJobsPage = () => {
 
     const refreshJobsIntervalMilliseconds = 5000;
 
-    // test job 
+    // test job
 
     const objectToAxiosParamsTestJob = (data) => ({
         url: `/api/jobs/launch/testjob?fail=${data.fail}&sleepMs=${data.sleepMs}`,
@@ -34,7 +36,7 @@ const AdminJobsPage = () => {
         testJobMutation.mutate(data);
     }
 
-    // Stryker disable all 
+    // Stryker disable all
     const { data: jobs, error: _error, status: _status } =
         useBackend(
             ["/api/jobs/all"],
@@ -45,12 +47,30 @@ const AdminJobsPage = () => {
             [],
             { refetchInterval: refreshJobsIntervalMilliseconds }
         );
-    // Stryker enable  all 
+    // Stryker enable  all
+
+    const objectToAxiosParamsUpdateCowHealthJob = () => ({
+        url: `/api/jobs/launch/updatecowhealth`,
+        method: "POST"
+    });
+
+    // Stryker disable all
+    const UpdateCowHealthMutation = useBackendMutation(
+        objectToAxiosParamsUpdateCowHealthJob,
+        {  },
+        ["/api/jobs/all"]
+    );
+    // Stryker enable all
+
+    const submitUpdateCowHealthJob = async () => {
+        console.log("submitUpdateCowHealthJob")
+        UpdateCowHealthMutation.mutate();
+    }
 
     const jobLaunchers = [
         {
             name: "Update Cow Health",
-            form: <UpdateCowHealthForm />
+            form: <UpdateCowHealthForm submitAction={submitUpdateCowHealthJob}/>
         },
         {
             name: "Milk The Cows",

--- a/frontend/src/main/pages/AdminJobsPage.js
+++ b/frontend/src/main/pages/AdminJobsPage.js
@@ -1,5 +1,3 @@
-// adminjobspage
-
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import JobsTable from "main/components/Jobs/JobsTable";
@@ -15,8 +13,6 @@ import { useBackendMutation } from "main/utils/useBackend";
 const AdminJobsPage = () => {
 
     const refreshJobsIntervalMilliseconds = 5000;
-
-    // test job
 
     const objectToAxiosParamsTestJob = (data) => ({
         url: `/api/jobs/launch/testjob?fail=${data.fail}&sleepMs=${data.sleepMs}`,
@@ -81,7 +77,6 @@ const AdminJobsPage = () => {
             form: <InstructorReportForm />
         },
     ]
-
 
     return (
         <BasicLayout>

--- a/frontend/src/stories/components/Jobs/UpdateCowHealthForm.stories.mdx
+++ b/frontend/src/stories/components/Jobs/UpdateCowHealthForm.stories.mdx
@@ -1,0 +1,19 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
+import { action } from "@storybook/addon-actions";
+import UpdateCowHealthForm from "main/components/Jobs/UpdateCowHealthForm";
+
+<Meta
+  title="components/Jobs/UpdateCowHealthForm"
+  component={UpdateCowHealthForm}
+/>
+
+# UpdateCowHealthForm
+
+A button for updating cow health, with:
+* a line telling the user what the button does
+
+<Canvas>
+  <Story name="uncontrolled">
+    <UpdateCowHealthForm submitAction={action("submit")} />
+  </Story>
+</Canvas>

--- a/frontend/src/stories/pages/AdminJobsPage.stories.js
+++ b/frontend/src/stories/pages/AdminJobsPage.stories.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import AdminJobsPage from "main/pages/AdminJobsPage";
+
+export default {
+    title: 'pages/AdminJobsPage',
+    component: AdminJobsPage
+};
+
+const Template = () => <AdminJobsPage />;
+
+export const Default = Template.bind({});

--- a/frontend/src/tests/components/Jobs/UpdateCowHealthForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateCowHealthForm.test.js
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router-dom";
+import UpdateCowHealthForm from "main/components/Jobs/UpdateCowHealthForm";
+import jobsFixtures from "fixtures/jobsFixtures";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
+}));
+
+describe("UpdateCowHealth tests", () => {
+  it("renders correctly with the right defaults", async () => {
+    render(
+      <Router >
+        <UpdateCowHealthForm jobs={jobsFixtures.threeUpdates}/>
+      </Router>
+    );
+
+    expect(screen.getByText(/Update/)).toBeInTheDocument();
+  });
+
+});

--- a/frontend/src/tests/components/Jobs/UpdateCowHealthForm.test.js
+++ b/frontend/src/tests/components/Jobs/UpdateCowHealthForm.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router-dom";
 import UpdateCowHealthForm from "main/components/Jobs/UpdateCowHealthForm";
 import jobsFixtures from "fixtures/jobsFixtures";

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -81,5 +81,30 @@ describe("AdminJobsPage tests", () => {
         expect(axiosMock.history.post[0].url).toBe("/api/jobs/launch/testjob?fail=false&sleepMs=0");
 });
 
+test("user can update cow healath", async () => {
+    render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <AdminJobsPage />
+            </MemoryRouter>
+        </QueryClientProvider>
+    );
+
+    expect(await screen.findByText("Update Cow Health")).toBeInTheDocument();
+
+    const UpdateCowHealthJobButton = screen.getByText("Update Cow Health");
+    expect(UpdateCowHealthJobButton).toBeInTheDocument();
+    UpdateCowHealthJobButton.click();
+
+    const submitButton = screen.getByTestId("UpdateCowHealthForm-Submit-Button");
+
+    expect(submitButton).toBeInTheDocument();
+    submitButton.click();
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].url).toBe("/api/jobs/launch/updatecowhealth");
+});
+
 
 });


### PR DESCRIPTION
In this PR, we implemented frontend changes to allow admins to launch the `CowHealthUpdateJob`, replacing the placeholder by creating the update button and linking it to `UpdateCowHealthJob.java`. To test, run on localhost or heroku, and go to Admin -> Manage Jobs -> Update Cow Health, and try clicking on the `Update` button and checking if it shows up under Job Status (like below). 
![image](https://user-images.githubusercontent.com/78510771/204899329-d1d6b70f-800b-4232-ae8f-8dde6ea7c4de.png)

Storybook links:
AdminsJobPage:
https://ucsb-cs156-f22.github.io/f22-5pm-happycows-docs-qa/storybook-qa/CyrilUpdateCowHealthFrontend/?path=/story/pages-adminjobspage--default
UpdateCowHealthForm:
https://ucsb-cs156-f22.github.io/f22-5pm-happycows-docs-qa/storybook-qa/CyrilUpdateCowHealthFrontend/?path=/story/components-jobs-updatecowhealthform--uncontrolled
