### PR TITLE
ol - Implement wealth increase with cow ownership (in the Milk The Cows Job)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
@@ -43,15 +43,19 @@ public class MilkTheCowsJob implements JobContextConsumer {
             Iterable<Commons> allCommons = commonsRepository.findAll();
             for (Commons commons : allCommons) {
                 Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
-                long milkPrice = commons.getMilkPrice();
-                
+                double commonsMilkPrice = commons.getMilkPrice();
+
                 for (UserCommons userCommons: allUserCommons) {
                     long userId = userCommons.getUserId();
+                    int userNumCows = userCommons.getNumOfCows();
+                    double userCowHealth = userCommons.getCowHealth();
+
+                    double currentWealth = userCommons.getTotalWealth();
+
+                    double newWealth = currentWealth + commonsMilkPrice*userNumCows*userCowHealth;
+                    userCommons.setTotalWealth(newWealth);
                 }
             }
-            // for each common
-            //     for each player in common
-            //         update wealth: add milkPrice*(cows*cowHealth) to player's wealth4
         }
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
@@ -57,5 +57,6 @@ public class MilkTheCowsJob implements JobContextConsumer {
                 }
             }
         }
+        // ctx.log("It works!");
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJob.java
@@ -1,16 +1,57 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+
+import edu.ucsb.cs156.happiercows.entities.User;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.entities.Commons;
+
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import lombok.Builder;
 
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
 @Builder
 public class MilkTheCowsJob implements JobContextConsumer {
+    @Autowired
+    private UserCommonsRepository userCommonsRepository;
+
+    @Autowired
+    private CommonsRepository commonsRepository;
 
     @Override
     public void accept(JobContext ctx) throws Exception {
-        ctx.log("Starting to milk the cows");
-        ctx.log("This is where the code to milk the cows will go.");
-        ctx.log("Cows have been milked!");
+        // ctx.log("Starting to milk the cows");
+        // ctx.log("This is where the code to milk the cows will go.");
+        // ctx.log("Cows have been milked!");
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern("HH:mm:ss");
+        if (LocalTime.now().equals("04:00:00")) {
+            Iterable<Commons> allCommons = commonsRepository.findAll();
+            for (Commons commons : allCommons) {
+                Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
+                long milkPrice = commons.getMilkPrice();
+                
+                for (UserCommons userCommons: allUserCommons) {
+                    long userId = userCommons.getUserId();
+                }
+            }
+            // for each common
+            //     for each player in common
+            //         update wealth: add milkPrice*(cows*cowHealth) to player's wealth4
+        }
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/MilkTheCowsJobTests.java
@@ -23,9 +23,7 @@ public class MilkTheCowsJobTests {
 
         // Assert
 
-        String expected = "Starting to milk the cows\n" +
-                "This is where the code to milk the cows will go.\n" +
-                "Cows have been milked!";
+        String expected = null;
 
         assertEquals(expected, jobStarted.getLog());
 


### PR DESCRIPTION
In this PR, we added the necessary functionality to update the user's wealth at 4am by the given amount as indicated in issue #30 . Whenever the milkTheCowsJob is launched at 4am, it should increment all the user's wealth by the necessary amount. 
To test this PR, you can run on either localhost or heroku,  go to swagger-UI and from the jobs-controller execute the following job: /api/jobs/launch/milkthecowjob . If the localTime is 4:00:00 it should add the necessary amount to each user's wealth
![image](https://user-images.githubusercontent.com/56096858/204950418-d4cb3c9c-d35e-4d31-9f6d-defda5df3150.png)
