### PR TITLE
cw - Adjust cow health over time

### DIFF
--- a/frontend/src/fixtures/jobsFixtures.js
+++ b/frontend/src/fixtures/jobsFixtures.js
@@ -78,21 +78,21 @@ const jobsFixtures = {
         "createdAt": "2022-11-13T19:49:58.097465-08:00",
         "updatedAt": "2022-11-13T19:49:59.203879-08:00",
         "status": "complete",
-        "log": "Updating cow health\nThis is where the code to update the cow health will go.\nCow health has been updated!"
+        "log": "Updating cow health\nCow health has been updated!"
       },
       {
         "id": 2,
         "createdAt": "2022-11-13T19:49:58.097465-08:00",
         "updatedAt": "2022-11-13T19:49:59.203879-08:00",
         "status": "running",
-        "log": "Updating cow health\nThis is where the code to update the cow health will go.\nCow health has been updated!"
+        "log": "Updating cow health"
       },
       {
         "id":3,
         "createdAt": "2022-11-13T19:49:58.097465-08:00",
         "updatedAt": "2022-11-13T19:49:59.203879-08:00",
         "status": "error",
-        "log": "Updating cow health\nThis is where the code to update the cow health will go.\nCow health has been updated!"
+        "log": "Error updating cow health"
       }
     ],
 };

--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -21,6 +21,10 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             Header: 'Cows Owned',
             accessor: 'numOfCows', 
         },
+        {
+            Header: 'Cow Health',
+            accessor: 'cowHealth', 
+        },
     ];
 
     const testid = "LeaderboardTable";

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -65,8 +65,8 @@ describe("LeaderboardTable tests", () => {
 
     );
 
-    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned'];
-    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows'];
+    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned', 'Cow Health'];
+    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth'];
     const testId = "LeaderboardTable";
 
     expectedHeaders.forEach((headerText) => {

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -23,6 +23,7 @@ import edu.ucsb.cs156.happiercows.jobs.InstructorReportJob;
 import edu.ucsb.cs156.happiercows.jobs.MilkTheCowsJob;
 import edu.ucsb.cs156.happiercows.jobs.TestJob;
 import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJob;
+import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJobFactory;
 import edu.ucsb.cs156.happiercows.repositories.jobs.JobsRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobService;
 
@@ -41,6 +42,9 @@ public class JobsController extends ApiController {
 
     @Autowired
     ObjectMapper mapper;
+
+    @Autowired
+    UpdateCowHealthJobFactory updateCowHealthJobFactory;
 
     @ApiOperation(value = "List all jobs")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -79,7 +83,7 @@ public class JobsController extends ApiController {
     @PostMapping("/launch/updatecowhealth")
     public Job updateCowHealth(
     ) { 
-        UpdateCowHealthJob updateCowHealthJob = UpdateCowHealthJob.builder().build();
+        UpdateCowHealthJob updateCowHealthJob = updateCowHealthJobFactory.create();
         return jobService.runAsJob(updateCowHealthJob);
     }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/JobsController.java
@@ -8,7 +8,7 @@ import io.swagger.annotations.ApiParam;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
-
+import org.springframework.context.annotation.Import;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/jobs/Job.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/jobs/Job.java
@@ -35,5 +35,7 @@ public class Job {
     private ZonedDateTime updatedAt;
 
     private String status;
+
+    @Column(columnDefinition="text")
     private String log;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -1,15 +1,18 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
 import java.util.Optional;
+
+
 import java.util.Iterator;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
+import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
-
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.AllArgsConstructor;
@@ -18,40 +21,55 @@ import lombok.AllArgsConstructor;
 @Slf4j
 public class UpdateCowHealthJob implements JobContextConsumer {
 
-    @Getter private CommonsRepository commonsRepository;
-    @Getter private UserCommonsRepository userCommonsRepository;
+    @Getter
+    private CommonsRepository commonsRepository;
+    @Getter
+    private UserCommonsRepository userCommonsRepository;
+    @Getter
+    private UserRepository userRepository;
 
     @Override
     public void accept(JobContext ctx) throws Exception {
-        ctx.log("Updating cow health");
+        ctx.log("Updating cow health...");
 
         Iterable<Commons> allCommons = commonsRepository.findAll();
 
         for (Commons commons : allCommons) {
+            ctx.log("Commons " + commons.getName() + ", degradationRate: " + commons.getDegradationRate() + ", carryingCapacity: " + commons.getCarryingCapacity());
+
             int carryingCapacity = commons.getCarryingCapacity();
-            double threshold = commons.getDegradationRate();
+            double degradationRate = commons.getDegradationRate();
             Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
 
-            // get totalCows  
-            Optional<Integer> numCows = commonsRepository.getNumCows(commons.getId());
-            CommonsPlus commonsPlus = CommonsPlus.builder().commons(commons).totalCows(numCows.orElse(0)).build();
-            Integer totalCows = commonsPlus.getTotalCows();
+            Integer totalCows = commonsRepository.getNumCows(commons.getId()).orElseThrow(()->new RuntimeException("Error calling getNumCows(" + commons.getId() + ")"));
 
             for (UserCommons userCommons : allUserCommons) {
-                if (totalCows <= carryingCapacity) {
-                    // increase cow health but do not exceed 100
-                    userCommons.setCowHealth(Math.min(100, userCommons.getCowHealth() + (threshold)));
-                    userCommonsRepository.save(userCommons);
-                }
-                else {
-                    // decrease cow health, don't go lower than 0
-                    userCommons.setCowHealth(Math.max(0, userCommons.getCowHealth() - Math.min((totalCows-carryingCapacity)*threshold,100)));
-                    userCommonsRepository.save(userCommons);
-                }
+                User user = userRepository.findById(userCommons.getUserId()).orElseThrow(()->new RuntimeException("Error calling User.findById(" + userCommons.getUserId() + ")"));
+                ctx.log("User: " + user.getFullName() + ", numCows: " + userCommons.getNumOfCows() + ", cowHealth: " + userCommons.getCowHealth());
+
+                double newCowHealth = calculateNewCowHealth(userCommons.getCowHealth(), userCommons.getNumOfCows(), totalCows, carryingCapacity, degradationRate);
+                ctx.log(" old cow health: " + userCommons.getCowHealth() + ", new cow health: " + newCowHealth);
+                userCommons.setCowHealth(newCowHealth);
+                userCommonsRepository.save(userCommons);
             }
         }
 
         ctx.log("Cow health has been updated!");
     }
-    
+
+    public static double calculateNewCowHealth(
+            double oldCowHealth,
+            int numCows,
+            int totalCows,
+            int carryingCapacity,
+            double degradationRate) {
+        if (totalCows <= carryingCapacity) {
+            // increase cow health but do not exceed 100
+            return Math.min(100, oldCowHealth + (degradationRate));
+        } else {
+            // decrease cow health, don't go lower than 0
+            return Math.max(0, oldCowHealth - Math.min((totalCows - carryingCapacity) * degradationRate, 100));
+        }
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -44,7 +44,7 @@ public class UpdateCowHealthJob implements JobContextConsumer {
             Integer totalCows = commonsRepository.getNumCows(commons.getId()).orElseThrow(()->new RuntimeException("Error calling getNumCows(" + commons.getId() + ")"));
 
             for (UserCommons userCommons : allUserCommons) {
-                User user = userRepository.findById(userCommons.getUserId()).orElseThrow(()->new RuntimeException("Error calling User.findById(" + userCommons.getUserId() + ")"));
+                User user = userRepository.findById(userCommons.getUserId()).orElseThrow(()->new RuntimeException("Error calling userRepository.findById(" + userCommons.getUserId() + ")"));
                 ctx.log("User: " + user.getFullName() + ", numCows: " + userCommons.getNumOfCows() + ", cowHealth: " + userCommons.getCowHealth());
 
                 double newCowHealth = calculateNewCowHealth(userCommons.getCowHealth(), userCommons.getNumOfCows(), totalCows, carryingCapacity, degradationRate);

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -30,7 +30,7 @@ public class UpdateCowHealthJob implements JobContextConsumer {
         Iterable<Commons> allCommons = commonsRepository.findAll();
 
         for (Commons commons : allCommons) {
-            int carryingCapacity = 100;
+            int carryingCapacity = commons.getCarryingCapacity();
             Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
 
             // get totalCows  
@@ -41,7 +41,7 @@ public class UpdateCowHealthJob implements JobContextConsumer {
             for (UserCommons userCommons : allUserCommons) {
                 if (totalCows <= carryingCapacity) {
                     // increase cow health but do not exceed 100
-                    userCommons.setCowHealth(Math.min(100, userCommons.getCowHealth() + (threshold*(carryingCapacity-totalCows))));
+                    userCommons.setCowHealth(Math.min(100, userCommons.getCowHealth() + (threshold)));
                     userCommonsRepository.save(userCommons);
                 }
                 else {

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -2,15 +2,65 @@ package edu.ucsb.cs156.happiercows.jobs;
 
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContextConsumer;
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import lombok.Getter;
 import lombok.Builder;
 
 @Builder
 public class UpdateCowHealthJob implements JobContextConsumer {
 
+    @Getter private CommonsRepository commonsRepository;
+    @Getter private UserCommonsRepository userCommonsRepository;
+
     @Override
     public void accept(JobContext ctx) throws Exception {
         ctx.log("Updating cow health");
-        ctx.log("This is where the code to update the cow health will go.");
+
+        int carryingCapacity = 100;
+        double threshold = 0.01;
+    //  for each commons that exists in the database:
+    //      totalCows = get the total number of cows in that commons
+    //      for each user in that commons:
+    //          get the number of cows that user has
+    //          get the average health of that users cows
+    //          calculate the new health of the cows 
+    //          using the formula in the stories, and assign it
+    //      end for
+    //  end for
+        Iterable<Commons> allCommons = commonsRepository.findAll();
+
+        for (Commons commons : allCommons) {
+            try {
+                Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
+                // get totalCows
+                Integer totalCows = commons.getTotalCows();
+                for (UserCommons userCommons : allUserCommons) {
+                    if (totalCows <= carryingCapacity) {
+                        try {
+                            // increase cow health but do not exceed 100
+                            userCommons.setCowHealth(Math.min(100, userCommons.getCowHealth() + (threshold*(carryingCapacity-totalCows))));
+                        } catch (Exception f) {
+                            ctx.log("Error updating cow health: " + f.getMessage());
+                        }
+                    }
+                    else {
+                        try {
+                            // decrease cow health 
+                            userCommons.setCowHealth(Math.min(0, userCommons.getCowHealth() - Math.min((totalCows-carryingCapacity)*threshold,100)));
+                        } catch (Exception g) {
+                            ctx.log("Error updating cow health: " + g.getMessage());
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                ctx.log("Error updating cow health: " + e.getMessage());
+            }
+        }
+
+
         ctx.log("Cow health has been updated!");
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJob.java
@@ -25,12 +25,11 @@ public class UpdateCowHealthJob implements JobContextConsumer {
     public void accept(JobContext ctx) throws Exception {
         ctx.log("Updating cow health");
 
-        double threshold = 0.01;
-
         Iterable<Commons> allCommons = commonsRepository.findAll();
 
         for (Commons commons : allCommons) {
             int carryingCapacity = commons.getCarryingCapacity();
+            double threshold = commons.getDegradationRate();
             Iterable<UserCommons> allUserCommons = userCommonsRepository.findByCommonsId(commons.getId());
 
             // get totalCows  

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
@@ -17,9 +17,12 @@ public class UpdateCowHealthJobFactory  {
     @Autowired
     private UserCommonsRepository userCommonsRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
     public UpdateCowHealthJob create() {
         log.info("commonsRepository = " + commonsRepository);
         log.info("userCommonsRepository = " + userCommonsRepository);
-        return new UpdateCowHealthJob(commonsRepository, userCommonsRepository);
+        return new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 
 @Service

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
@@ -11,7 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class UpdateCowHealthJobFactory  {
 
-    @Autowired
+    @Autowired 
     private CommonsRepository commonsRepository;
   
     @Autowired

--- a/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactory.java
@@ -1,0 +1,25 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+public class UpdateCowHealthJobFactory  {
+
+    @Autowired
+    private CommonsRepository commonsRepository;
+  
+    @Autowired
+    private UserCommonsRepository userCommonsRepository;
+
+    public UpdateCowHealthJob create() {
+        log.info("commonsRepository = " + commonsRepository);
+        log.info("userCommonsRepository = " + userCommonsRepository);
+        return new UpdateCowHealthJob(commonsRepository, userCommonsRepository);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/JobsControllerTests.java
@@ -38,6 +38,10 @@ import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.repositories.jobs.JobsRepository;
 import edu.ucsb.cs156.happiercows.services.jobs.JobService;
+import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJob;
+import edu.ucsb.cs156.happiercows.jobs.UpdateCowHealthJobFactory;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -57,6 +61,16 @@ public class JobsControllerTests extends ControllerTestCase {
 
     @Autowired
     ObjectMapper objectMapper;
+
+    @MockBean
+    CommonsRepository commonsRepository;
+
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
+
+    @MockBean
+    UpdateCowHealthJobFactory updateCowHealthJobFactory;
+
 
     @WithMockUser(roles = { "ADMIN" })
     @Test

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UserCommonsControllerTests.java
@@ -141,7 +141,7 @@ public class UserCommonsControllerTests extends ControllerTestCase {
       // arrange
   
       UserCommons origUserCommons = UserCommons
-      .builder()
+            .builder()
       .id(1L)
       .userId(1L)
       .commonsId(1L)

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryTests.java
@@ -3,13 +3,11 @@ package edu.ucsb.cs156.happiercows.jobs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryTests.java
@@ -1,0 +1,3 @@
+public class UpdateCowHealthJobFactoryTests {
+    
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryTests.java
@@ -1,3 +1,42 @@
+package edu.ucsb.cs156.happiercows.jobs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+
+@RestClientTest(UpdateCowHealthJobFactory.class)
+@AutoConfigureDataJpa
 public class UpdateCowHealthJobFactoryTests {
-    
+
+    @MockBean
+    CommonsRepository commonsRepository;
+
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
+
+    @Autowired
+    UpdateCowHealthJobFactory updateCowHealthJobFactory;
+
+    @Test
+    void test_create() throws Exception {
+
+        // Act
+        UpdateCowHealthJob updateCowHealthJob = updateCowHealthJobFactory.create();
+
+        // Assert
+        assertEquals(commonsRepository,updateCowHealthJob.getCommonsRepository());
+        assertEquals(userCommonsRepository,updateCowHealthJob.getUserCommonsRepository());
+
+    }
 }
+

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobFactoryTests.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Import;
 
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 
 @RestClientTest(UpdateCowHealthJobFactory.class)
 @AutoConfigureDataJpa
@@ -23,6 +24,9 @@ public class UpdateCowHealthJobFactoryTests {
 
     @MockBean
     UserCommonsRepository userCommonsRepository;
+
+    @MockBean
+    UserRepository userRepository;
 
     @Autowired
     UpdateCowHealthJobFactory updateCowHealthJobFactory;
@@ -36,6 +40,7 @@ public class UpdateCowHealthJobFactoryTests {
         // Assert
         assertEquals(commonsRepository,updateCowHealthJob.getCommonsRepository());
         assertEquals(userCommonsRepository,updateCowHealthJob.getUserCommonsRepository());
+        assertEquals(userRepository,updateCowHealthJob.getUserRepository());
 
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -1,41 +1,26 @@
 package edu.ucsb.cs156.happiercows.jobs;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
-import java.util.Iterator;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
-import lombok.extern.slf4j.Slf4j;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
-import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
 import edu.ucsb.cs156.happiercows.entities.User;
 
 import java.time.LocalDateTime;
@@ -108,16 +93,6 @@ public class UpdateCowHealthJobTests {
                 .degradationRate(0.01)
                 .build();
 
-        UserCommons userCommonsToSend = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(1)
-                .cowHealth(10)
-                .build();
-
         UserCommons newUserCommons = UserCommons
                 .builder()
                 .id(1L)
@@ -179,16 +154,6 @@ public class UpdateCowHealthJobTests {
                 .startingDate(LocalDateTime.now())
                 .carryingCapacity(100)
                 .degradationRate(0.01)
-                .build();
-
-        UserCommons userCommonsToSend = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(101)
-                .cowHealth(100)
                 .build();
 
         UserCommons newUserCommons = UserCommons
@@ -254,16 +219,6 @@ public class UpdateCowHealthJobTests {
                 .degradationRate(0.01)
                 .build();
 
-        UserCommons userCommonsToSend = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(100)
-                .cowHealth(50)
-                .build();
-
         UserCommons newUserCommons = UserCommons
                 .builder()
                 .id(1L)
@@ -327,16 +282,6 @@ public class UpdateCowHealthJobTests {
                 .degradationRate(0.01)
                 .build();
 
-        UserCommons userCommonsToSend = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(150)
-                .cowHealth(0)
-                .build();
-
         UserCommons newUserCommons = UserCommons
                 .builder()
                 .id(1L)
@@ -398,16 +343,6 @@ public class UpdateCowHealthJobTests {
                 .startingDate(LocalDateTime.now())
                 .carryingCapacity(100)
                 .degradationRate(0.01)
-                .build();
-
-        UserCommons userCommonsToSend = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(1)
-                .cowHealth(100)
                 .build();
 
         UserCommons newUserCommons = UserCommons
@@ -491,16 +426,6 @@ public class UpdateCowHealthJobTests {
                 .startingDate(LocalDateTime.now())
                 .carryingCapacity(10)
                 .degradationRate(0.01)
-                .build();
-
-        UserCommons userCommonsToSend = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(5)
-                .cowHealth(50)
                 .build();
 
         UserCommons newUserCommons = UserCommons

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Iterator;
 
-
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -40,9 +40,8 @@ import edu.ucsb.cs156.happiercows.entities.User;
 
 import java.time.LocalDateTime;
 
-
 @ExtendWith(SpringExtension.class)
-@ContextConfiguration 
+@ContextConfiguration
 public class UpdateCowHealthJobTests {
     @Mock
     CommonsRepository commonsRepository;
@@ -54,11 +53,11 @@ public class UpdateCowHealthJobTests {
     UserRepository userRepository;
 
     private User user = User
-    .builder()
-    .id(1L)
-    .fullName("Chris Gaucho")
-    .email("cgaucho@example.org")
-    .build();
+            .builder()
+            .id(1L)
+            .fullName("Chris Gaucho")
+            .email("cgaucho@example.org")
+            .build();
 
     @Test
     void test_log_output_success() throws Exception {
@@ -69,13 +68,14 @@ public class UpdateCowHealthJobTests {
         JobContext ctx = new JobContext(null, jobStarted);
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                userRepository);
         updateCowHealthJob.accept(ctx);
 
         // Assert
         String expected = """
-            Updating cow health...
-            Cow health has been updated!""";
+                Updating cow health...
+                Cow health has been updated!""";
 
         assertEquals(expected, jobStarted.getLog());
     }
@@ -88,67 +88,66 @@ public class UpdateCowHealthJobTests {
         JobContext ctx = new JobContext(null, jobStarted);
 
         UserCommons origUserCommons = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300)
-        .numOfCows(1)
-        .cowHealth(10)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .cowHealth(10)
+                .build();
 
         Commons testCommons = Commons
-        .builder()
-        .name("test commons")
-        .cowPrice(10)
-        .milkPrice(2)
-        .startingBalance(300)
-        .startingDate(LocalDateTime.now())
-        .carryingCapacity(100)
-        .degradationRate(0.01)
-        .build();
+                .builder()
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .carryingCapacity(100)
+                .degradationRate(0.01)
+                .build();
 
         UserCommons userCommonsToSend = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300)
-        .numOfCows(1)
-        .cowHealth(10)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .cowHealth(10)
+                .build();
 
         UserCommons newUserCommons = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300-testCommons.getCowPrice())
-        .numOfCows(1)
-        .cowHealth(10.01)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300 - testCommons.getCowPrice())
+                .numOfCows(1)
+                .cowHealth(10.01)
+                .build();
 
-     
-
-        Commons commonsTemp[] = {testCommons};
-        UserCommons userCommonsTemp[] = {origUserCommons};
+        Commons commonsTemp[] = { testCommons };
+        UserCommons userCommonsTemp[] = { origUserCommons };
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
         when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                userRepository);
         updateCowHealthJob.accept(ctx);
 
         // Assert
 
         String expected = """
-            Updating cow health...
-            Commons test commons, degradationRate: 0.01, carryingCapacity: 100
-            User: Chris Gaucho, numCows: 1, cowHealth: 10.0
-             old cow health: 10.0, new cow health: 10.01
-            Cow health has been updated!""";
+                Updating cow health...
+                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
+                User: Chris Gaucho, numCows: 1, cowHealth: 10.0
+                 old cow health: 10.0, new cow health: 10.01
+                Cow health has been updated!""";
 
         assertEquals(expected, jobStarted.getLog());
         assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
@@ -162,65 +161,66 @@ public class UpdateCowHealthJobTests {
         JobContext ctx = new JobContext(null, jobStarted);
 
         UserCommons origUserCommons = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300)
-        .numOfCows(101)
-        .cowHealth(100)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(101)
+                .cowHealth(100)
+                .build();
 
         Commons testCommons = Commons
-        .builder()
-        .name("test commons")
-        .cowPrice(10)
-        .milkPrice(2)
-        .startingBalance(300)
-        .startingDate(LocalDateTime.now())
-        .carryingCapacity(100)
-        .degradationRate(0.01)
-        .build();
+                .builder()
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .carryingCapacity(100)
+                .degradationRate(0.01)
+                .build();
 
         UserCommons userCommonsToSend = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300)
-        .numOfCows(101)
-        .cowHealth(100)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(101)
+                .cowHealth(100)
+                .build();
 
         UserCommons newUserCommons = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300-testCommons.getCowPrice())
-        .numOfCows(101)
-        .cowHealth(99.99)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300 - testCommons.getCowPrice())
+                .numOfCows(101)
+                .cowHealth(99.99)
+                .build();
 
-        Commons commonsTemp[] = {testCommons};
-        UserCommons userCommonsTemp[] = {origUserCommons};
+        Commons commonsTemp[] = { testCommons };
+        UserCommons userCommonsTemp[] = { origUserCommons };
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
         when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(101)));
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                userRepository);
         updateCowHealthJob.accept(ctx);
 
         // Assert
 
         String expected = """
-            Updating cow health...
-            Commons test commons, degradationRate: 0.01, carryingCapacity: 100
-            User: Chris Gaucho, numCows: 101, cowHealth: 100.0
-             old cow health: 100.0, new cow health: 99.99
-            Cow health has been updated!""";
+                Updating cow health...
+                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
+                User: Chris Gaucho, numCows: 101, cowHealth: 100.0
+                 old cow health: 100.0, new cow health: 99.99
+                Cow health has been updated!""";
 
         assertEquals(expected, jobStarted.getLog());
         assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
@@ -234,65 +234,66 @@ public class UpdateCowHealthJobTests {
         JobContext ctx = new JobContext(null, jobStarted);
 
         UserCommons origUserCommons = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300)
-        .numOfCows(100)
-        .cowHealth(50)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(100)
+                .cowHealth(50)
+                .build();
 
         Commons testCommons = Commons
-        .builder()
-        .name("test commons")
-        .cowPrice(10)
-        .milkPrice(2)
-        .startingBalance(300)
-        .startingDate(LocalDateTime.now())
-        .carryingCapacity(100)
-        .degradationRate(0.01)
-        .build();
+                .builder()
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .carryingCapacity(100)
+                .degradationRate(0.01)
+                .build();
 
         UserCommons userCommonsToSend = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300)
-        .numOfCows(100)
-        .cowHealth(50)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(100)
+                .cowHealth(50)
+                .build();
 
         UserCommons newUserCommons = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300-testCommons.getCowPrice())
-        .numOfCows(100)
-        .cowHealth(50.01)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300 - testCommons.getCowPrice())
+                .numOfCows(100)
+                .cowHealth(50.01)
+                .build();
 
-        Commons commonsTemp[] = {testCommons};
-        UserCommons userCommonsTemp[] = {origUserCommons};
+        Commons commonsTemp[] = { testCommons };
+        UserCommons userCommonsTemp[] = { origUserCommons };
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
         when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(100)));
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                userRepository);
         updateCowHealthJob.accept(ctx);
 
         // Assert
 
         String expected = """
-            Updating cow health...
-            Commons test commons, degradationRate: 0.01, carryingCapacity: 100
-            User: Chris Gaucho, numCows: 100, cowHealth: 50.0
-             old cow health: 50.0, new cow health: 50.01
-            Cow health has been updated!""";
+                Updating cow health...
+                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
+                User: Chris Gaucho, numCows: 100, cowHealth: 50.0
+                 old cow health: 50.0, new cow health: 50.01
+                Cow health has been updated!""";
 
         assertEquals(expected, jobStarted.getLog());
         assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
@@ -306,65 +307,66 @@ public class UpdateCowHealthJobTests {
         JobContext ctx = new JobContext(null, jobStarted);
 
         UserCommons origUserCommons = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300)
-        .numOfCows(150)
-        .cowHealth(0)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(150)
+                .cowHealth(0)
+                .build();
 
         Commons testCommons = Commons
-        .builder()
-        .name("test commons")
-        .cowPrice(10)
-        .milkPrice(2)
-        .startingBalance(300)
-        .startingDate(LocalDateTime.now())
-        .carryingCapacity(100)
-        .degradationRate(0.01)
-        .build();
+                .builder()
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .carryingCapacity(100)
+                .degradationRate(0.01)
+                .build();
 
         UserCommons userCommonsToSend = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300)
-        .numOfCows(150)
-        .cowHealth(0)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(150)
+                .cowHealth(0)
+                .build();
 
         UserCommons newUserCommons = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300-testCommons.getCowPrice())
-        .numOfCows(150)
-        .cowHealth(0)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300 - testCommons.getCowPrice())
+                .numOfCows(150)
+                .cowHealth(0)
+                .build();
 
-        Commons commonsTemp[] = {testCommons};
-        UserCommons userCommonsTemp[] = {origUserCommons};
+        Commons commonsTemp[] = { testCommons };
+        UserCommons userCommonsTemp[] = { origUserCommons };
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
         when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(150)));
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                userRepository);
         updateCowHealthJob.accept(ctx);
 
         // Assert
 
         String expected = """
-            Updating cow health...
-            Commons test commons, degradationRate: 0.01, carryingCapacity: 100
-            User: Chris Gaucho, numCows: 150, cowHealth: 0.0
-             old cow health: 0.0, new cow health: 0.0
-            Cow health has been updated!""";
+                Updating cow health...
+                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
+                User: Chris Gaucho, numCows: 150, cowHealth: 0.0
+                 old cow health: 0.0, new cow health: 0.0
+                Cow health has been updated!""";
 
         assertEquals(expected, jobStarted.getLog());
         assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
@@ -378,65 +380,66 @@ public class UpdateCowHealthJobTests {
         JobContext ctx = new JobContext(null, jobStarted);
 
         UserCommons origUserCommons = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300)
-        .numOfCows(1)
-        .cowHealth(100)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .cowHealth(100)
+                .build();
 
         Commons testCommons = Commons
-        .builder()
-        .name("test commons")
-        .cowPrice(10)
-        .milkPrice(2)
-        .startingBalance(300)
-        .startingDate(LocalDateTime.now())
-        .carryingCapacity(100)
-        .degradationRate(0.01)
-        .build();
+                .builder()
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .carryingCapacity(100)
+                .degradationRate(0.01)
+                .build();
 
         UserCommons userCommonsToSend = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300)
-        .numOfCows(1)
-        .cowHealth(100)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .cowHealth(100)
+                .build();
 
         UserCommons newUserCommons = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300-testCommons.getCowPrice())
-        .numOfCows(1)
-        .cowHealth(100)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300 - testCommons.getCowPrice())
+                .numOfCows(1)
+                .cowHealth(100)
+                .build();
 
-        Commons commonsTemp[] = {testCommons};
-        UserCommons userCommonsTemp[] = {origUserCommons};
+        Commons commonsTemp[] = { testCommons };
+        UserCommons userCommonsTemp[] = { origUserCommons };
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
         when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                userRepository);
         updateCowHealthJob.accept(ctx);
 
         // Assert
 
         String expected = """
-            Updating cow health...
-            Commons test commons, degradationRate: 0.01, carryingCapacity: 100
-            User: Chris Gaucho, numCows: 1, cowHealth: 100.0
-             old cow health: 100.0, new cow health: 100.0
-            Cow health has been updated!""";
+                Updating cow health...
+                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
+                User: Chris Gaucho, numCows: 1, cowHealth: 100.0
+                 old cow health: 100.0, new cow health: 100.0
+                Cow health has been updated!""";
 
         assertEquals(expected, jobStarted.getLog());
         assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
@@ -450,89 +453,90 @@ public class UpdateCowHealthJobTests {
         JobContext ctx = new JobContext(null, jobStarted);
 
         UserCommons origUserCommons1 = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300)
-        .numOfCows(5)
-        .cowHealth(50)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(5)
+                .cowHealth(50)
+                .build();
 
         UserCommons origUserCommons2 = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300)
-        .numOfCows(5)
-        .cowHealth(50)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(5)
+                .cowHealth(50)
+                .build();
 
         UserCommons origUserCommons3 = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300)
-        .numOfCows(5)
-        .cowHealth(50)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(5)
+                .cowHealth(50)
+                .build();
 
         Commons testCommons = Commons
-        .builder()
-        .name("test commons")
-        .cowPrice(10)
-        .milkPrice(2)
-        .startingBalance(300)
-        .startingDate(LocalDateTime.now())
-        .carryingCapacity(10)
-        .degradationRate(0.01)
-        .build();
+                .builder()
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .carryingCapacity(10)
+                .degradationRate(0.01)
+                .build();
 
         UserCommons userCommonsToSend = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300)
-        .numOfCows(5)
-        .cowHealth(50)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(5)
+                .cowHealth(50)
+                .build();
 
         UserCommons newUserCommons = UserCommons
-        .builder()
-        .id(1L)
-        .userId(1L)
-        .commonsId(1L)
-        .totalWealth(300-testCommons.getCowPrice())
-        .numOfCows(5)
-        .cowHealth(50.01)
-        .build();
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300 - testCommons.getCowPrice())
+                .numOfCows(5)
+                .cowHealth(50.01)
+                .build();
 
-        Commons commonsTemp[] = {testCommons};
-        UserCommons userCommonsTemp[] = {origUserCommons1, origUserCommons2, origUserCommons3};
+        Commons commonsTemp[] = { testCommons };
+        UserCommons userCommonsTemp[] = { origUserCommons1, origUserCommons2, origUserCommons3 };
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
         when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                userRepository);
         updateCowHealthJob.accept(ctx);
 
         // Assert
 
         String expected = """
-            Updating cow health...
-            Commons test commons, degradationRate: 0.01, carryingCapacity: 10
-            User: Chris Gaucho, numCows: 5, cowHealth: 50.0
-             old cow health: 50.0, new cow health: 50.01
-            User: Chris Gaucho, numCows: 5, cowHealth: 50.0
-             old cow health: 50.0, new cow health: 50.01
-            User: Chris Gaucho, numCows: 5, cowHealth: 50.0
-             old cow health: 50.0, new cow health: 50.01
-            Cow health has been updated!""";
+                Updating cow health...
+                Commons test commons, degradationRate: 0.01, carryingCapacity: 10
+                User: Chris Gaucho, numCows: 5, cowHealth: 50.0
+                 old cow health: 50.0, new cow health: 50.01
+                User: Chris Gaucho, numCows: 5, cowHealth: 50.0
+                 old cow health: 50.0, new cow health: 50.01
+                User: Chris Gaucho, numCows: 5, cowHealth: 50.0
+                 old cow health: 50.0, new cow health: 50.01
+                Cow health has been updated!""";
 
         assertEquals(expected, jobStarted.getLog());
         assertEquals(origUserCommons1.getCowHealth(), newUserCommons.getCowHealth());
@@ -540,5 +544,102 @@ public class UpdateCowHealthJobTests {
         assertEquals(origUserCommons3.getCowHealth(), newUserCommons.getCowHealth());
     }
 
+    @Test
+    void test_throws_exception_when_get_num_cows_fails() throws Exception {
+
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        UserCommons origUserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(1L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .cowHealth(10)
+                .build();
+
+        Commons testCommons = Commons
+                .builder()
+                .id(117L)
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .carryingCapacity(100)
+                .degradationRate(0.01)
+                .build();
+
+        Commons commonsTemp[] = { testCommons };
+        UserCommons userCommonsTemp[] = { origUserCommons };
+        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+        when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
+        when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.empty());
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // Act
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                userRepository);
+
+        RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () -> {
+            // Code under test
+            updateCowHealthJob.accept(ctx);
+        });
+
+        Assertions.assertEquals("Error calling getNumCows(117)", thrown.getMessage());
+
+    }
+
+    @Test
+    void test_throws_exception_when_getting_user_fails() throws Exception {
+
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        UserCommons origUserCommons = UserCommons
+                .builder()
+                .id(1L)
+                .userId(321L)
+                .commonsId(1L)
+                .totalWealth(300)
+                .numOfCows(1)
+                .cowHealth(10)
+                .build();
+
+        Commons testCommons = Commons
+                .builder()
+                .id(117L)
+                .name("test commons")
+                .cowPrice(10)
+                .milkPrice(2)
+                .startingBalance(300)
+                .startingDate(LocalDateTime.now())
+                .carryingCapacity(100)
+                .degradationRate(0.01)
+                .build();
+
+        Commons commonsTemp[] = { testCommons };
+        UserCommons userCommonsTemp[] = { origUserCommons };
+        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+        when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
+        when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(10));
+        when(userRepository.findById(321L)).thenReturn(Optional.empty());
+
+        // Act
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                userRepository);
+
+        RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () -> {
+            // Code under test
+            updateCowHealthJob.accept(ctx);
+        });
+
+        Assertions.assertEquals("Error calling userRepository.findById(321)", thrown.getMessage());
+
+    }
 
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -32,9 +32,12 @@ import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import lombok.extern.slf4j.Slf4j;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import edu.ucsb.cs156.happiercows.entities.Commons;
 import edu.ucsb.cs156.happiercows.entities.UserCommons;
 import edu.ucsb.cs156.happiercows.entities.CommonsPlus;
+import edu.ucsb.cs156.happiercows.entities.User;
+
 import java.time.LocalDateTime;
 
 
@@ -47,6 +50,16 @@ public class UpdateCowHealthJobTests {
     @Mock
     UserCommonsRepository userCommonsRepository;
 
+    @Mock
+    UserRepository userRepository;
+
+    private User user = User
+    .builder()
+    .id(1L)
+    .fullName("Chris Gaucho")
+    .email("cgaucho@example.org")
+    .build();
+
     @Test
     void test_log_output_success() throws Exception {
 
@@ -56,12 +69,12 @@ public class UpdateCowHealthJobTests {
         JobContext ctx = new JobContext(null, jobStarted);
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository);
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
         updateCowHealthJob.accept(ctx);
 
         // Assert
         String expected = """
-            Updating cow health
+            Updating cow health...
             Cow health has been updated!""";
 
         assertEquals(expected, jobStarted.getLog());
@@ -115,20 +128,26 @@ public class UpdateCowHealthJobTests {
         .cowHealth(10.01)
         .build();
 
+     
+
         Commons commonsTemp[] = {testCommons};
         UserCommons userCommonsTemp[] = {origUserCommons};
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
         when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository);
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
         updateCowHealthJob.accept(ctx);
 
         // Assert
 
         String expected = """
-            Updating cow health
+            Updating cow health...
+            Commons test commons, degradationRate: 0.01, carryingCapacity: 100
+            User: Chris Gaucho, numCows: 1, cowHealth: 10.0
+             old cow health: 10.0, new cow health: 10.01
             Cow health has been updated!""";
 
         assertEquals(expected, jobStarted.getLog());
@@ -188,15 +207,19 @@ public class UpdateCowHealthJobTests {
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
         when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(101)));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository);
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
         updateCowHealthJob.accept(ctx);
 
         // Assert
 
         String expected = """
-            Updating cow health
+            Updating cow health...
+            Commons test commons, degradationRate: 0.01, carryingCapacity: 100
+            User: Chris Gaucho, numCows: 101, cowHealth: 100.0
+             old cow health: 100.0, new cow health: 99.99
             Cow health has been updated!""";
 
         assertEquals(expected, jobStarted.getLog());
@@ -256,15 +279,19 @@ public class UpdateCowHealthJobTests {
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
         when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(100)));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository);
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
         updateCowHealthJob.accept(ctx);
 
         // Assert
 
         String expected = """
-            Updating cow health
+            Updating cow health...
+            Commons test commons, degradationRate: 0.01, carryingCapacity: 100
+            User: Chris Gaucho, numCows: 100, cowHealth: 50.0
+             old cow health: 50.0, new cow health: 50.01
             Cow health has been updated!""";
 
         assertEquals(expected, jobStarted.getLog());
@@ -324,15 +351,19 @@ public class UpdateCowHealthJobTests {
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
         when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(150)));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository);
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
         updateCowHealthJob.accept(ctx);
 
         // Assert
 
         String expected = """
-            Updating cow health
+            Updating cow health...
+            Commons test commons, degradationRate: 0.01, carryingCapacity: 100
+            User: Chris Gaucho, numCows: 150, cowHealth: 0.0
+             old cow health: 0.0, new cow health: 0.0
             Cow health has been updated!""";
 
         assertEquals(expected, jobStarted.getLog());
@@ -392,15 +423,19 @@ public class UpdateCowHealthJobTests {
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
         when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository);
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
         updateCowHealthJob.accept(ctx);
 
         // Assert
 
         String expected = """
-            Updating cow health
+            Updating cow health...
+            Commons test commons, degradationRate: 0.01, carryingCapacity: 100
+            User: Chris Gaucho, numCows: 1, cowHealth: 100.0
+             old cow health: 100.0, new cow health: 100.0
             Cow health has been updated!""";
 
         assertEquals(expected, jobStarted.getLog());
@@ -480,15 +515,23 @@ public class UpdateCowHealthJobTests {
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
         when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository);
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository, userRepository);
         updateCowHealthJob.accept(ctx);
 
         // Assert
 
         String expected = """
-            Updating cow health
+            Updating cow health...
+            Commons test commons, degradationRate: 0.01, carryingCapacity: 10
+            User: Chris Gaucho, numCows: 5, cowHealth: 50.0
+             old cow health: 50.0, new cow health: 50.01
+            User: Chris Gaucho, numCows: 5, cowHealth: 50.0
+             old cow health: 50.0, new cow health: 50.01
+            User: Chris Gaucho, numCows: 5, cowHealth: 50.0
+             old cow health: 50.0, new cow health: 50.01
             Cow health has been updated!""";
 
         assertEquals(expected, jobStarted.getLog());

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -92,6 +92,7 @@ public class UpdateCowHealthJobTests {
         .startingBalance(300)
         .startingDate(LocalDateTime.now())
         .carryingCapacity(100)
+        .degradationRate(0.01)
         .build();
 
         UserCommons userCommonsToSend = UserCommons
@@ -159,6 +160,7 @@ public class UpdateCowHealthJobTests {
         .startingBalance(300)
         .startingDate(LocalDateTime.now())
         .carryingCapacity(100)
+        .degradationRate(0.01)
         .build();
 
         UserCommons userCommonsToSend = UserCommons
@@ -226,6 +228,7 @@ public class UpdateCowHealthJobTests {
         .startingBalance(300)
         .startingDate(LocalDateTime.now())
         .carryingCapacity(100)
+        .degradationRate(0.01)
         .build();
 
         UserCommons userCommonsToSend = UserCommons
@@ -293,6 +296,7 @@ public class UpdateCowHealthJobTests {
         .startingBalance(300)
         .startingDate(LocalDateTime.now())
         .carryingCapacity(100)
+        .degradationRate(0.01)
         .build();
 
         UserCommons userCommonsToSend = UserCommons
@@ -360,6 +364,7 @@ public class UpdateCowHealthJobTests {
         .startingBalance(300)
         .startingDate(LocalDateTime.now())
         .carryingCapacity(100)
+        .degradationRate(0.01)
         .build();
 
         UserCommons userCommonsToSend = UserCommons
@@ -401,5 +406,96 @@ public class UpdateCowHealthJobTests {
         assertEquals(expected, jobStarted.getLog());
         assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
     }
+
+    @Test
+    void test_updating_to_new_values_for_multiple() throws Exception {
+
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        UserCommons origUserCommons1 = UserCommons
+        .builder()
+        .id(1L)
+        .userId(1L)
+        .commonsId(1L)
+        .totalWealth(300)
+        .numOfCows(5)
+        .cowHealth(50)
+        .build();
+
+        UserCommons origUserCommons2 = UserCommons
+        .builder()
+        .id(1L)
+        .userId(1L)
+        .commonsId(1L)
+        .totalWealth(300)
+        .numOfCows(5)
+        .cowHealth(50)
+        .build();
+
+        UserCommons origUserCommons3 = UserCommons
+        .builder()
+        .id(1L)
+        .userId(1L)
+        .commonsId(1L)
+        .totalWealth(300)
+        .numOfCows(5)
+        .cowHealth(50)
+        .build();
+
+        Commons testCommons = Commons
+        .builder()
+        .name("test commons")
+        .cowPrice(10)
+        .milkPrice(2)
+        .startingBalance(300)
+        .startingDate(LocalDateTime.now())
+        .carryingCapacity(10)
+        .degradationRate(0.01)
+        .build();
+
+        UserCommons userCommonsToSend = UserCommons
+        .builder()
+        .id(1L)
+        .userId(1L)
+        .commonsId(1L)
+        .totalWealth(300)
+        .numOfCows(5)
+        .cowHealth(50)
+        .build();
+
+        UserCommons newUserCommons = UserCommons
+        .builder()
+        .id(1L)
+        .userId(1L)
+        .commonsId(1L)
+        .totalWealth(300-testCommons.getCowPrice())
+        .numOfCows(5)
+        .cowHealth(50.01)
+        .build();
+
+        Commons commonsTemp[] = {testCommons};
+        UserCommons userCommonsTemp[] = {origUserCommons1, origUserCommons2, origUserCommons3};
+        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+        when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
+        when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+
+        // Act
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository);
+        updateCowHealthJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+            Updating cow health
+            Cow health has been updated!""";
+
+        assertEquals(expected, jobStarted.getLog());
+        assertEquals(origUserCommons1.getCowHealth(), newUserCommons.getCowHealth());
+        assertEquals(origUserCommons2.getCowHealth(), newUserCommons.getCowHealth());
+        assertEquals(origUserCommons3.getCowHealth(), newUserCommons.getCowHealth());
+    }
+
 
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -13,7 +13,6 @@ import org.mockito.Mock;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
@@ -28,543 +27,639 @@ import java.time.LocalDateTime;
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration
 public class UpdateCowHealthJobTests {
-    @Mock
-    CommonsRepository commonsRepository;
-
-    @Mock
-    UserCommonsRepository userCommonsRepository;
-
-    @Mock
-    UserRepository userRepository;
-
-    private User user = User
-            .builder()
-            .id(1L)
-            .fullName("Chris Gaucho")
-            .email("cgaucho@example.org")
-            .build();
-
-    @Test
-    void test_log_output_success() throws Exception {
-
-        // Arrange
-
-        Job jobStarted = Job.builder().build();
-        JobContext ctx = new JobContext(null, jobStarted);
-
-        // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                userRepository);
-        updateCowHealthJob.accept(ctx);
-
-        // Assert
-        String expected = """
-                Updating cow health...
-                Cow health has been updated!""";
-
-        assertEquals(expected, jobStarted.getLog());
-    }
-
-    @Test
-    void test_updating_to_new_values_if_less_than_carrying_capacity() throws Exception {
-
-        // Arrange
-        Job jobStarted = Job.builder().build();
-        JobContext ctx = new JobContext(null, jobStarted);
-
-        UserCommons origUserCommons = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(1)
-                .cowHealth(10)
-                .build();
-
-        Commons testCommons = Commons
-                .builder()
-                .name("test commons")
-                .cowPrice(10)
-                .milkPrice(2)
-                .startingBalance(300)
-                .startingDate(LocalDateTime.now())
-                .carryingCapacity(100)
-                .degradationRate(0.01)
-                .build();
-
-        UserCommons newUserCommons = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300 - testCommons.getCowPrice())
-                .numOfCows(1)
-                .cowHealth(10.01)
-                .build();
-
-        Commons commonsTemp[] = { testCommons };
-        UserCommons userCommonsTemp[] = { origUserCommons };
-        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-        when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
-        when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-        // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                userRepository);
-        updateCowHealthJob.accept(ctx);
-
-        // Assert
-
-        String expected = """
-                Updating cow health...
-                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
-                User: Chris Gaucho, numCows: 1, cowHealth: 10.0
-                 old cow health: 10.0, new cow health: 10.01
-                Cow health has been updated!""";
-
-        assertEquals(expected, jobStarted.getLog());
-        assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
-    }
-
-    @Test
-    void test_updating_to_new_values_if_greater_than_carrying_capacity() throws Exception {
-
-        // Arrange
-        Job jobStarted = Job.builder().build();
-        JobContext ctx = new JobContext(null, jobStarted);
-
-        UserCommons origUserCommons = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(101)
-                .cowHealth(100)
-                .build();
-
-        Commons testCommons = Commons
-                .builder()
-                .name("test commons")
-                .cowPrice(10)
-                .milkPrice(2)
-                .startingBalance(300)
-                .startingDate(LocalDateTime.now())
-                .carryingCapacity(100)
-                .degradationRate(0.01)
-                .build();
-
-        UserCommons newUserCommons = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300 - testCommons.getCowPrice())
-                .numOfCows(101)
-                .cowHealth(99.99)
-                .build();
-
-        Commons commonsTemp[] = { testCommons };
-        UserCommons userCommonsTemp[] = { origUserCommons };
-        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-        when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
-        when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(101)));
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-        // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                userRepository);
-        updateCowHealthJob.accept(ctx);
-
-        // Assert
-
-        String expected = """
-                Updating cow health...
-                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
-                User: Chris Gaucho, numCows: 101, cowHealth: 100.0
-                 old cow health: 100.0, new cow health: 99.99
-                Cow health has been updated!""";
-
-        assertEquals(expected, jobStarted.getLog());
-        assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
-    }
-
-    @Test
-    void test_updating_to_new_values_if_equal_to_carrying_capacity() throws Exception {
-
-        // Arrange
-        Job jobStarted = Job.builder().build();
-        JobContext ctx = new JobContext(null, jobStarted);
-
-        UserCommons origUserCommons = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(100)
-                .cowHealth(50)
-                .build();
-
-        Commons testCommons = Commons
-                .builder()
-                .name("test commons")
-                .cowPrice(10)
-                .milkPrice(2)
-                .startingBalance(300)
-                .startingDate(LocalDateTime.now())
-                .carryingCapacity(100)
-                .degradationRate(0.01)
-                .build();
-
-        UserCommons newUserCommons = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300 - testCommons.getCowPrice())
-                .numOfCows(100)
-                .cowHealth(50.01)
-                .build();
-
-        Commons commonsTemp[] = { testCommons };
-        UserCommons userCommonsTemp[] = { origUserCommons };
-        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-        when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
-        when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(100)));
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-        // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                userRepository);
-        updateCowHealthJob.accept(ctx);
-
-        // Assert
-
-        String expected = """
-                Updating cow health...
-                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
-                User: Chris Gaucho, numCows: 100, cowHealth: 50.0
-                 old cow health: 50.0, new cow health: 50.01
-                Cow health has been updated!""";
-
-        assertEquals(expected, jobStarted.getLog());
-        assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
-    }
-
-    @Test
-    void test_updating_to_new_values_health_lower_than_zero() throws Exception {
-
-        // Arrange
-        Job jobStarted = Job.builder().build();
-        JobContext ctx = new JobContext(null, jobStarted);
-
-        UserCommons origUserCommons = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(150)
-                .cowHealth(0)
-                .build();
-
-        Commons testCommons = Commons
-                .builder()
-                .name("test commons")
-                .cowPrice(10)
-                .milkPrice(2)
-                .startingBalance(300)
-                .startingDate(LocalDateTime.now())
-                .carryingCapacity(100)
-                .degradationRate(0.01)
-                .build();
-
-        UserCommons newUserCommons = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300 - testCommons.getCowPrice())
-                .numOfCows(150)
-                .cowHealth(0)
-                .build();
-
-        Commons commonsTemp[] = { testCommons };
-        UserCommons userCommonsTemp[] = { origUserCommons };
-        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-        when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
-        when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(150)));
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-        // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                userRepository);
-        updateCowHealthJob.accept(ctx);
-
-        // Assert
-
-        String expected = """
-                Updating cow health...
-                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
-                User: Chris Gaucho, numCows: 150, cowHealth: 0.0
-                 old cow health: 0.0, new cow health: 0.0
-                Cow health has been updated!""";
-
-        assertEquals(expected, jobStarted.getLog());
-        assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
-    }
-
-    @Test
-    void test_updating_to_new_values_health_greater_than_100() throws Exception {
-
-        // Arrange
-        Job jobStarted = Job.builder().build();
-        JobContext ctx = new JobContext(null, jobStarted);
-
-        UserCommons origUserCommons = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(1)
-                .cowHealth(100)
-                .build();
-
-        Commons testCommons = Commons
-                .builder()
-                .name("test commons")
-                .cowPrice(10)
-                .milkPrice(2)
-                .startingBalance(300)
-                .startingDate(LocalDateTime.now())
-                .carryingCapacity(100)
-                .degradationRate(0.01)
-                .build();
-
-        UserCommons newUserCommons = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300 - testCommons.getCowPrice())
-                .numOfCows(1)
-                .cowHealth(100)
-                .build();
-
-        Commons commonsTemp[] = { testCommons };
-        UserCommons userCommonsTemp[] = { origUserCommons };
-        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-        when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
-        when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-        // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                userRepository);
-        updateCowHealthJob.accept(ctx);
-
-        // Assert
-
-        String expected = """
-                Updating cow health...
-                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
-                User: Chris Gaucho, numCows: 1, cowHealth: 100.0
-                 old cow health: 100.0, new cow health: 100.0
-                Cow health has been updated!""";
-
-        assertEquals(expected, jobStarted.getLog());
-        assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
-    }
-
-    @Test
-    void test_updating_to_new_values_for_multiple() throws Exception {
-
-        // Arrange
-        Job jobStarted = Job.builder().build();
-        JobContext ctx = new JobContext(null, jobStarted);
-
-        UserCommons origUserCommons1 = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(5)
-                .cowHealth(50)
-                .build();
-
-        UserCommons origUserCommons2 = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(5)
-                .cowHealth(50)
-                .build();
-
-        UserCommons origUserCommons3 = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(5)
-                .cowHealth(50)
-                .build();
-
-        Commons testCommons = Commons
-                .builder()
-                .name("test commons")
-                .cowPrice(10)
-                .milkPrice(2)
-                .startingBalance(300)
-                .startingDate(LocalDateTime.now())
-                .carryingCapacity(10)
-                .degradationRate(0.01)
-                .build();
-
-        UserCommons newUserCommons = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300 - testCommons.getCowPrice())
-                .numOfCows(5)
-                .cowHealth(50.01)
-                .build();
-
-        Commons commonsTemp[] = { testCommons };
-        UserCommons userCommonsTemp[] = { origUserCommons1, origUserCommons2, origUserCommons3 };
-        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-        when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
-        when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-        // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                userRepository);
-        updateCowHealthJob.accept(ctx);
-
-        // Assert
-
-        String expected = """
-                Updating cow health...
-                Commons test commons, degradationRate: 0.01, carryingCapacity: 10
-                User: Chris Gaucho, numCows: 5, cowHealth: 50.0
-                 old cow health: 50.0, new cow health: 50.01
-                User: Chris Gaucho, numCows: 5, cowHealth: 50.0
-                 old cow health: 50.0, new cow health: 50.01
-                User: Chris Gaucho, numCows: 5, cowHealth: 50.0
-                 old cow health: 50.0, new cow health: 50.01
-                Cow health has been updated!""";
-
-        assertEquals(expected, jobStarted.getLog());
-        assertEquals(origUserCommons1.getCowHealth(), newUserCommons.getCowHealth());
-        assertEquals(origUserCommons2.getCowHealth(), newUserCommons.getCowHealth());
-        assertEquals(origUserCommons3.getCowHealth(), newUserCommons.getCowHealth());
-    }
-
-    @Test
-    void test_throws_exception_when_get_num_cows_fails() throws Exception {
-
-        // Arrange
-        Job jobStarted = Job.builder().build();
-        JobContext ctx = new JobContext(null, jobStarted);
-
-        UserCommons origUserCommons = UserCommons
-                .builder()
-                .id(1L)
-                .userId(1L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(1)
-                .cowHealth(10)
-                .build();
-
-        Commons testCommons = Commons
-                .builder()
-                .id(117L)
-                .name("test commons")
-                .cowPrice(10)
-                .milkPrice(2)
-                .startingBalance(300)
-                .startingDate(LocalDateTime.now())
-                .carryingCapacity(100)
-                .degradationRate(0.01)
-                .build();
-
-        Commons commonsTemp[] = { testCommons };
-        UserCommons userCommonsTemp[] = { origUserCommons };
-        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-        when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
-        when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.empty());
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-
-        // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                userRepository);
-
-        RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () -> {
-            // Code under test
-            updateCowHealthJob.accept(ctx);
-        });
-
-        Assertions.assertEquals("Error calling getNumCows(117)", thrown.getMessage());
-
-    }
-
-    @Test
-    void test_throws_exception_when_getting_user_fails() throws Exception {
-
-        // Arrange
-        Job jobStarted = Job.builder().build();
-        JobContext ctx = new JobContext(null, jobStarted);
-
-        UserCommons origUserCommons = UserCommons
-                .builder()
-                .id(1L)
-                .userId(321L)
-                .commonsId(1L)
-                .totalWealth(300)
-                .numOfCows(1)
-                .cowHealth(10)
-                .build();
-
-        Commons testCommons = Commons
-                .builder()
-                .id(117L)
-                .name("test commons")
-                .cowPrice(10)
-                .milkPrice(2)
-                .startingBalance(300)
-                .startingDate(LocalDateTime.now())
-                .carryingCapacity(100)
-                .degradationRate(0.01)
-                .build();
-
-        Commons commonsTemp[] = { testCommons };
-        UserCommons userCommonsTemp[] = { origUserCommons };
-        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
-        when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
-        when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(10));
-        when(userRepository.findById(321L)).thenReturn(Optional.empty());
-
-        // Act
-        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
-                userRepository);
-
-        RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () -> {
-            // Code under test
-            updateCowHealthJob.accept(ctx);
-        });
-
-        Assertions.assertEquals("Error calling userRepository.findById(321)", thrown.getMessage());
-
-    }
+        @Mock
+        CommonsRepository commonsRepository;
+
+        @Mock
+        UserCommonsRepository userCommonsRepository;
+
+        @Mock
+        UserRepository userRepository;
+
+        private User user = User
+                        .builder()
+                        .id(1L)
+                        .fullName("Chris Gaucho")
+                        .email("cgaucho@example.org")
+                        .build();
+
+        @Test
+        void test_log_output_success() throws Exception {
+
+                // Arrange
+
+                Job jobStarted = Job.builder().build();
+                JobContext ctx = new JobContext(null, jobStarted);
+
+                // Act
+                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                                userRepository);
+                updateCowHealthJob.accept(ctx);
+
+                // Assert
+                String expected = """
+                                Updating cow health...
+                                Cow health has been updated!""";
+
+                assertEquals(expected, jobStarted.getLog());
+        }
+
+        @Test
+        void test_updating_to_new_values_if_less_than_carrying_capacity() throws Exception {
+
+                // Arrange
+                Job jobStarted = Job.builder().build();
+                JobContext ctx = new JobContext(null, jobStarted);
+
+                UserCommons origUserCommons = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300)
+                                .numOfCows(1)
+                                .cowHealth(10)
+                                .build();
+
+                Commons testCommons = Commons
+                                .builder()
+                                .name("test commons")
+                                .cowPrice(10)
+                                .milkPrice(2)
+                                .startingBalance(300)
+                                .startingDate(LocalDateTime.now())
+                                .carryingCapacity(100)
+                                .degradationRate(0.01)
+                                .build();
+
+                UserCommons newUserCommons = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300 - testCommons.getCowPrice())
+                                .numOfCows(1)
+                                .cowHealth(10.01)
+                                .build();
+
+                Commons commonsTemp[] = { testCommons };
+                UserCommons userCommonsTemp[] = { origUserCommons };
+                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
+                                .thenReturn(Arrays.asList(userCommonsTemp));
+                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+                // Act
+                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                                userRepository);
+                updateCowHealthJob.accept(ctx);
+
+                // Assert
+
+                String expected = """
+                                Updating cow health...
+                                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
+                                User: Chris Gaucho, numCows: 1, cowHealth: 10.0
+                                 old cow health: 10.0, new cow health: 10.01
+                                Cow health has been updated!""";
+
+                assertEquals(expected, jobStarted.getLog());
+                assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
+        }
+
+        @Test
+        void test_updating_to_new_values_if_greater_than_carrying_capacity() throws Exception {
+
+                // Arrange
+                Job jobStarted = Job.builder().build();
+                JobContext ctx = new JobContext(null, jobStarted);
+
+                UserCommons origUserCommons = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300)
+                                .numOfCows(101)
+                                .cowHealth(100)
+                                .build();
+
+                Commons testCommons = Commons
+                                .builder()
+                                .name("test commons")
+                                .cowPrice(10)
+                                .milkPrice(2)
+                                .startingBalance(300)
+                                .startingDate(LocalDateTime.now())
+                                .carryingCapacity(100)
+                                .degradationRate(0.01)
+                                .build();
+
+                UserCommons newUserCommons = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300 - testCommons.getCowPrice())
+                                .numOfCows(101)
+                                .cowHealth(99.99)
+                                .build();
+
+                Commons commonsTemp[] = { testCommons };
+                UserCommons userCommonsTemp[] = { origUserCommons };
+                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
+                                .thenReturn(Arrays.asList(userCommonsTemp));
+                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(101)));
+                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+                // Act
+                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                                userRepository);
+                updateCowHealthJob.accept(ctx);
+
+                // Assert
+
+                String expected = """
+                                Updating cow health...
+                                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
+                                User: Chris Gaucho, numCows: 101, cowHealth: 100.0
+                                 old cow health: 100.0, new cow health: 99.99
+                                Cow health has been updated!""";
+
+                assertEquals(expected, jobStarted.getLog());
+                assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
+        }
+
+        @Test
+        void test_updating_to_new_values_if_equal_to_carrying_capacity() throws Exception {
+
+                // Arrange
+                Job jobStarted = Job.builder().build();
+                JobContext ctx = new JobContext(null, jobStarted);
+
+                UserCommons origUserCommons = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300)
+                                .numOfCows(100)
+                                .cowHealth(50)
+                                .build();
+
+                Commons testCommons = Commons
+                                .builder()
+                                .name("test commons")
+                                .cowPrice(10)
+                                .milkPrice(2)
+                                .startingBalance(300)
+                                .startingDate(LocalDateTime.now())
+                                .carryingCapacity(100)
+                                .degradationRate(0.01)
+                                .build();
+
+                UserCommons newUserCommons = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300 - testCommons.getCowPrice())
+                                .numOfCows(100)
+                                .cowHealth(50.01)
+                                .build();
+
+                Commons commonsTemp[] = { testCommons };
+                UserCommons userCommonsTemp[] = { origUserCommons };
+                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
+                                .thenReturn(Arrays.asList(userCommonsTemp));
+                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(100)));
+                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+                // Act
+                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                                userRepository);
+                updateCowHealthJob.accept(ctx);
+
+                // Assert
+
+                String expected = """
+                                Updating cow health...
+                                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
+                                User: Chris Gaucho, numCows: 100, cowHealth: 50.0
+                                 old cow health: 50.0, new cow health: 50.01
+                                Cow health has been updated!""";
+
+                assertEquals(expected, jobStarted.getLog());
+                assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
+        }
+
+        @Test
+        void test_updating_to_new_values_health_lower_than_zero() throws Exception {
+
+                // Arrange
+                Job jobStarted = Job.builder().build();
+                JobContext ctx = new JobContext(null, jobStarted);
+
+                UserCommons origUserCommons = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300)
+                                .numOfCows(150)
+                                .cowHealth(0)
+                                .build();
+
+                Commons testCommons = Commons
+                                .builder()
+                                .name("test commons")
+                                .cowPrice(10)
+                                .milkPrice(2)
+                                .startingBalance(300)
+                                .startingDate(LocalDateTime.now())
+                                .carryingCapacity(100)
+                                .degradationRate(0.01)
+                                .build();
+
+                UserCommons newUserCommons = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300 - testCommons.getCowPrice())
+                                .numOfCows(150)
+                                .cowHealth(0)
+                                .build();
+
+                Commons commonsTemp[] = { testCommons };
+                UserCommons userCommonsTemp[] = { origUserCommons };
+                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
+                                .thenReturn(Arrays.asList(userCommonsTemp));
+                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(150)));
+                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+                // Act
+                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                                userRepository);
+                updateCowHealthJob.accept(ctx);
+
+                // Assert
+
+                String expected = """
+                                Updating cow health...
+                                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
+                                User: Chris Gaucho, numCows: 150, cowHealth: 0.0
+                                 old cow health: 0.0, new cow health: 0.0
+                                Cow health has been updated!""";
+
+                assertEquals(expected, jobStarted.getLog());
+                assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
+        }
+
+        @Test
+        void test_updating_to_new_values_health_greater_than_100() throws Exception {
+
+                // Arrange
+                Job jobStarted = Job.builder().build();
+                JobContext ctx = new JobContext(null, jobStarted);
+
+                UserCommons origUserCommons = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300)
+                                .numOfCows(1)
+                                .cowHealth(100)
+                                .build();
+
+                Commons testCommons = Commons
+                                .builder()
+                                .name("test commons")
+                                .cowPrice(10)
+                                .milkPrice(2)
+                                .startingBalance(300)
+                                .startingDate(LocalDateTime.now())
+                                .carryingCapacity(100)
+                                .degradationRate(0.01)
+                                .build();
+
+                UserCommons newUserCommons = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300 - testCommons.getCowPrice())
+                                .numOfCows(1)
+                                .cowHealth(100)
+                                .build();
+
+                Commons commonsTemp[] = { testCommons };
+                UserCommons userCommonsTemp[] = { origUserCommons };
+                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
+                                .thenReturn(Arrays.asList(userCommonsTemp));
+                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+                // Act
+                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                                userRepository);
+                updateCowHealthJob.accept(ctx);
+
+                // Assert
+
+                String expected = """
+                                Updating cow health...
+                                Commons test commons, degradationRate: 0.01, carryingCapacity: 100
+                                User: Chris Gaucho, numCows: 1, cowHealth: 100.0
+                                 old cow health: 100.0, new cow health: 100.0
+                                Cow health has been updated!""";
+
+                assertEquals(expected, jobStarted.getLog());
+                assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
+        }
+
+        @Test
+        void test_updating_to_new_values_for_multiple() throws Exception {
+
+                // Arrange
+                Job jobStarted = Job.builder().build();
+                JobContext ctx = new JobContext(null, jobStarted);
+
+                UserCommons origUserCommons1 = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300)
+                                .numOfCows(5)
+                                .cowHealth(50)
+                                .build();
+
+                UserCommons origUserCommons2 = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300)
+                                .numOfCows(5)
+                                .cowHealth(50)
+                                .build();
+
+                UserCommons origUserCommons3 = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300)
+                                .numOfCows(5)
+                                .cowHealth(50)
+                                .build();
+
+                Commons testCommons = Commons
+                                .builder()
+                                .name("test commons")
+                                .cowPrice(10)
+                                .milkPrice(2)
+                                .startingBalance(300)
+                                .startingDate(LocalDateTime.now())
+                                .carryingCapacity(10)
+                                .degradationRate(0.01)
+                                .build();
+
+                UserCommons newUserCommons = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300 - testCommons.getCowPrice())
+                                .numOfCows(5)
+                                .cowHealth(50.01)
+                                .build();
+
+                Commons commonsTemp[] = { testCommons };
+                UserCommons userCommonsTemp[] = { origUserCommons1, origUserCommons2, origUserCommons3 };
+                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
+                                .thenReturn(Arrays.asList(userCommonsTemp));
+                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
+                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+                // Act
+                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                                userRepository);
+                updateCowHealthJob.accept(ctx);
+
+                // Assert
+
+                String expected = """
+                                Updating cow health...
+                                Commons test commons, degradationRate: 0.01, carryingCapacity: 10
+                                User: Chris Gaucho, numCows: 5, cowHealth: 50.0
+                                 old cow health: 50.0, new cow health: 50.01
+                                User: Chris Gaucho, numCows: 5, cowHealth: 50.0
+                                 old cow health: 50.0, new cow health: 50.01
+                                User: Chris Gaucho, numCows: 5, cowHealth: 50.0
+                                 old cow health: 50.0, new cow health: 50.01
+                                Cow health has been updated!""";
+
+                assertEquals(expected, jobStarted.getLog());
+                assertEquals(origUserCommons1.getCowHealth(), newUserCommons.getCowHealth());
+                assertEquals(origUserCommons2.getCowHealth(), newUserCommons.getCowHealth());
+                assertEquals(origUserCommons3.getCowHealth(), newUserCommons.getCowHealth());
+        }
+
+        @Test
+        void test_throws_exception_when_get_num_cows_fails() throws Exception {
+
+                // Arrange
+                Job jobStarted = Job.builder().build();
+                JobContext ctx = new JobContext(null, jobStarted);
+
+                UserCommons origUserCommons = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(1L)
+                                .commonsId(1L)
+                                .totalWealth(300)
+                                .numOfCows(1)
+                                .cowHealth(10)
+                                .build();
+
+                Commons testCommons = Commons
+                                .builder()
+                                .id(117L)
+                                .name("test commons")
+                                .cowPrice(10)
+                                .milkPrice(2)
+                                .startingBalance(300)
+                                .startingDate(LocalDateTime.now())
+                                .carryingCapacity(100)
+                                .degradationRate(0.01)
+                                .build();
+
+                Commons commonsTemp[] = { testCommons };
+                UserCommons userCommonsTemp[] = { origUserCommons };
+                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
+                                .thenReturn(Arrays.asList(userCommonsTemp));
+                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.empty());
+                when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+                // Act
+                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                                userRepository);
+
+                RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () -> {
+                        // Code under test
+                        updateCowHealthJob.accept(ctx);
+                });
+
+                Assertions.assertEquals("Error calling getNumCows(117)", thrown.getMessage());
+
+        }
+
+        @Test
+        void test_throws_exception_when_getting_user_fails() throws Exception {
+
+                // Arrange
+                Job jobStarted = Job.builder().build();
+                JobContext ctx = new JobContext(null, jobStarted);
+
+                UserCommons origUserCommons = UserCommons
+                                .builder()
+                                .id(1L)
+                                .userId(321L)
+                                .commonsId(1L)
+                                .totalWealth(300)
+                                .numOfCows(1)
+                                .cowHealth(10)
+                                .build();
+
+                Commons testCommons = Commons
+                                .builder()
+                                .id(117L)
+                                .name("test commons")
+                                .cowPrice(10)
+                                .milkPrice(2)
+                                .startingBalance(300)
+                                .startingDate(LocalDateTime.now())
+                                .carryingCapacity(100)
+                                .degradationRate(0.01)
+                                .build();
+
+                Commons commonsTemp[] = { testCommons };
+                UserCommons userCommonsTemp[] = { origUserCommons };
+                when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+                when(userCommonsRepository.findByCommonsId(testCommons.getId()))
+                                .thenReturn(Arrays.asList(userCommonsTemp));
+                when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(10));
+                when(userRepository.findById(321L)).thenReturn(Optional.empty());
+
+                // Act
+                UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository,
+                                userRepository);
+
+                RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () -> {
+                        // Code under test
+                        updateCowHealthJob.accept(ctx);
+                });
+
+                Assertions.assertEquals("Error calling userRepository.findById(321)", thrown.getMessage());
+
+        }
+
+        @Test
+        void test_calculateNewCowHealth__numCows_lt_carryingCapacity_old_health_at_100__no_change() {
+             
+                // arrange
+              
+                double oldCowHealth = 100.0;
+                int numCows = 50;
+                int totalCows = 80;
+                int carryingCapacity = 100;
+                double degradationRate = 3.0;
+
+                // act
+
+                double newCowHealth = UpdateCowHealthJob.calculateNewCowHealth(oldCowHealth, numCows, totalCows,
+                                carryingCapacity, degradationRate);
+
+                // assert
+
+                assertEquals(100.0, newCowHealth);
+
+        }
+
+        @Test
+        void test_calculateNewCowHealth__numCows_lt_carryingCapacity_old_health_at_80__goes_up() {
+             
+                // arrange
+              
+                double oldCowHealth = 80.123;
+                int numCows = 50;
+                int totalCows = 80;
+                int carryingCapacity = 100;
+                double degradationRate = 3.456;
+
+                // act
+
+                double newCowHealth = UpdateCowHealthJob.calculateNewCowHealth(oldCowHealth, numCows, totalCows,
+                                carryingCapacity, degradationRate);
+
+                // assert
+
+                assertEquals(83.579, newCowHealth, 0.0001);
+
+        }
+
+        @Test
+        void test_calculateNewCowHealth__numCows_one_over_carryingCapacity_old_health_at_80__goes_down_by_degradation_rate() {
+             
+                // arrange
+              
+                double oldCowHealth = 83.579;
+                int numCows = 50;
+                int totalCows = 101;
+                int carryingCapacity = 100;
+                double degradationRate = 3.456;
+
+                // act
+
+                double newCowHealth = UpdateCowHealthJob.calculateNewCowHealth(oldCowHealth, numCows, totalCows,
+                                carryingCapacity, degradationRate);
+
+                // assert
+
+                assertEquals(80.123, newCowHealth, 0.0001);
+
+        }
+
+        @Test
+        void test_calculateNewCowHealth__numCows_ten_over_carryingCapacity_old_health_at_80__goes_down_by_degradation_rate_times_10() {
+             
+                // arrange
+              
+                double oldCowHealth = 100.0;
+                int numCows = 50;
+                int totalCows = 110;
+                int carryingCapacity = 100;
+                double degradationRate = 1.234;
+
+                // act
+
+                double newCowHealth = UpdateCowHealthJob.calculateNewCowHealth(oldCowHealth, numCows, totalCows,
+                                carryingCapacity, degradationRate);
+
+                // assert
+
+                assertEquals((100.0 - 12.34), newCowHealth, 0.0001);
+
+        }
 
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -3,11 +3,23 @@ package edu.ucsb.cs156.happiercows.jobs;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import edu.ucsb.cs156.happiercows.entities.jobs.Job;
 import edu.ucsb.cs156.happiercows.services.jobs.JobContext;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 
+@Slf4j
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration 
 public class UpdateCowHealthJobTests {
+    @Autowired
+    UpdateCowHealthJobFactory updateCowHealthJobFactory;
+
     @Test
     void test_log_output() throws Exception {
 
@@ -17,8 +29,7 @@ public class UpdateCowHealthJobTests {
         JobContext ctx = new JobContext(null, jobStarted);
 
         // Act
-        UpdateCowHealthJob updateCowHealthJob = UpdateCowHealthJob.builder()
-                .build();
+        UpdateCowHealthJob updateCowHealthJob = updateCowHealthJobFactory.create();
         updateCowHealthJob.accept(ctx);
 
         // Assert

--- a/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/jobs/UpdateCowHealthJobTests.java
@@ -91,6 +91,7 @@ public class UpdateCowHealthJobTests {
         .milkPrice(2)
         .startingBalance(300)
         .startingDate(LocalDateTime.now())
+        .carryingCapacity(100)
         .build();
 
         UserCommons userCommonsToSend = UserCommons
@@ -110,7 +111,7 @@ public class UpdateCowHealthJobTests {
         .commonsId(1L)
         .totalWealth(300-testCommons.getCowPrice())
         .numOfCows(1)
-        .cowHealth(10.99)
+        .cowHealth(10.01)
         .build();
 
         Commons commonsTemp[] = {testCommons};
@@ -157,6 +158,7 @@ public class UpdateCowHealthJobTests {
         .milkPrice(2)
         .startingBalance(300)
         .startingDate(LocalDateTime.now())
+        .carryingCapacity(100)
         .build();
 
         UserCommons userCommonsToSend = UserCommons
@@ -184,6 +186,207 @@ public class UpdateCowHealthJobTests {
         when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
         when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
         when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(101)));
+
+        // Act
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository);
+        updateCowHealthJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+            Updating cow health
+            Cow health has been updated!""";
+
+        assertEquals(expected, jobStarted.getLog());
+        assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
+    }
+
+    @Test
+    void test_updating_to_new_values_if_equal_to_carrying_capacity() throws Exception {
+
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        UserCommons origUserCommons = UserCommons
+        .builder()
+        .id(1L)
+        .userId(1L)
+        .commonsId(1L)
+        .totalWealth(300)
+        .numOfCows(100)
+        .cowHealth(50)
+        .build();
+
+        Commons testCommons = Commons
+        .builder()
+        .name("test commons")
+        .cowPrice(10)
+        .milkPrice(2)
+        .startingBalance(300)
+        .startingDate(LocalDateTime.now())
+        .carryingCapacity(100)
+        .build();
+
+        UserCommons userCommonsToSend = UserCommons
+        .builder()
+        .id(1L)
+        .userId(1L)
+        .commonsId(1L)
+        .totalWealth(300)
+        .numOfCows(100)
+        .cowHealth(50)
+        .build();
+
+        UserCommons newUserCommons = UserCommons
+        .builder()
+        .id(1L)
+        .userId(1L)
+        .commonsId(1L)
+        .totalWealth(300-testCommons.getCowPrice())
+        .numOfCows(100)
+        .cowHealth(50.01)
+        .build();
+
+        Commons commonsTemp[] = {testCommons};
+        UserCommons userCommonsTemp[] = {origUserCommons};
+        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+        when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
+        when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(100)));
+
+        // Act
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository);
+        updateCowHealthJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+            Updating cow health
+            Cow health has been updated!""";
+
+        assertEquals(expected, jobStarted.getLog());
+        assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
+    }
+
+    @Test
+    void test_updating_to_new_values_health_lower_than_zero() throws Exception {
+
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        UserCommons origUserCommons = UserCommons
+        .builder()
+        .id(1L)
+        .userId(1L)
+        .commonsId(1L)
+        .totalWealth(300)
+        .numOfCows(150)
+        .cowHealth(0)
+        .build();
+
+        Commons testCommons = Commons
+        .builder()
+        .name("test commons")
+        .cowPrice(10)
+        .milkPrice(2)
+        .startingBalance(300)
+        .startingDate(LocalDateTime.now())
+        .carryingCapacity(100)
+        .build();
+
+        UserCommons userCommonsToSend = UserCommons
+        .builder()
+        .id(1L)
+        .userId(1L)
+        .commonsId(1L)
+        .totalWealth(300)
+        .numOfCows(150)
+        .cowHealth(0)
+        .build();
+
+        UserCommons newUserCommons = UserCommons
+        .builder()
+        .id(1L)
+        .userId(1L)
+        .commonsId(1L)
+        .totalWealth(300-testCommons.getCowPrice())
+        .numOfCows(150)
+        .cowHealth(0)
+        .build();
+
+        Commons commonsTemp[] = {testCommons};
+        UserCommons userCommonsTemp[] = {origUserCommons};
+        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+        when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
+        when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(150)));
+
+        // Act
+        UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository);
+        updateCowHealthJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+            Updating cow health
+            Cow health has been updated!""";
+
+        assertEquals(expected, jobStarted.getLog());
+        assertEquals(origUserCommons.getCowHealth(), newUserCommons.getCowHealth());
+    }
+
+    @Test
+    void test_updating_to_new_values_health_greater_than_100() throws Exception {
+
+        // Arrange
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        UserCommons origUserCommons = UserCommons
+        .builder()
+        .id(1L)
+        .userId(1L)
+        .commonsId(1L)
+        .totalWealth(300)
+        .numOfCows(1)
+        .cowHealth(100)
+        .build();
+
+        Commons testCommons = Commons
+        .builder()
+        .name("test commons")
+        .cowPrice(10)
+        .milkPrice(2)
+        .startingBalance(300)
+        .startingDate(LocalDateTime.now())
+        .carryingCapacity(100)
+        .build();
+
+        UserCommons userCommonsToSend = UserCommons
+        .builder()
+        .id(1L)
+        .userId(1L)
+        .commonsId(1L)
+        .totalWealth(300)
+        .numOfCows(1)
+        .cowHealth(100)
+        .build();
+
+        UserCommons newUserCommons = UserCommons
+        .builder()
+        .id(1L)
+        .userId(1L)
+        .commonsId(1L)
+        .totalWealth(300-testCommons.getCowPrice())
+        .numOfCows(1)
+        .cowHealth(100)
+        .build();
+
+        Commons commonsTemp[] = {testCommons};
+        UserCommons userCommonsTemp[] = {origUserCommons};
+        when(commonsRepository.findAll()).thenReturn(Arrays.asList(commonsTemp));
+        when(userCommonsRepository.findByCommonsId(testCommons.getId())).thenReturn(Arrays.asList(userCommonsTemp));
+        when(commonsRepository.getNumCows(testCommons.getId())).thenReturn(Optional.of(Integer.valueOf(1)));
 
         // Act
         UpdateCowHealthJob updateCowHealthJob = new UpdateCowHealthJob(commonsRepository, userCommonsRepository);


### PR DESCRIPTION
In this PR, we implemented the job for adjusting cow health over time based on the number of cows in the commons. 

To test, I recommend running on localhost or heroku, and navigate to Admin -> Manage Jobs -> Update Cow Health, then click `Update`. 
![image](https://user-images.githubusercontent.com/78510771/204959130-0b78448b-5305-4b8a-937f-72fd168f6566.png)
From there, the cow health field show in the play page should increase or decrease based on the number of cows and carrying capacity. 
![image](https://user-images.githubusercontent.com/78510771/204959185-15861e54-5eb4-48b9-8308-328d6de63eb2.png)
It may be a little tough for this since the carrying capacity is unable to be changed yet through the `CreateCommonPage`, but should be easier to test if we change it so that we can select the carrying capacity. 
