### PR TITLE
pc - add cow health to leaderboard

### DIFF
--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -21,6 +21,10 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             Header: 'Cows Owned',
             accessor: 'numOfCows', 
         },
+        {
+            Header: 'Cow Health',
+            accessor: 'cowHealth', 
+        },
     ];
 
     const testid = "LeaderboardTable";

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -65,8 +65,8 @@ describe("LeaderboardTable tests", () => {
 
     );
 
-    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned'];
-    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows'];
+    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned', 'Cow Health'];
+    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth'];
     const testId = "LeaderboardTable";
 
     expectedHeaders.forEach((headerText) => {


### PR DESCRIPTION
In this Staff PR, we add cow health to the leaderboard, to be better able to track what happens when cow health is updated.