### PR TITLE
Add cow health to leaderboard, and fix bug with job logging (crashes when more than 255 chars)

### DIFF
--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -21,6 +21,10 @@ export default function LeaderboardTable({ leaderboardUsers , currentUser }) {
             Header: 'Cows Owned',
             accessor: 'numOfCows', 
         },
+        {
+            Header: 'Cow Health',
+            accessor: 'cowHealth', 
+        },
     ];
 
     const testid = "LeaderboardTable";

--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -65,8 +65,8 @@ describe("LeaderboardTable tests", () => {
 
     );
 
-    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned'];
-    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows'];
+    const expectedHeaders = ['(Admin) userCommons Id', 'Username', 'User Id', 'Total Wealth', 'Cows Owned', 'Cow Health'];
+    const expectedFields = ['id', 'userId', 'username', 'totalWealth','numOfCows', 'cowHealth'];
     const testId = "LeaderboardTable";
 
     expectedHeaders.forEach((headerText) => {

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/jobs/Job.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/jobs/Job.java
@@ -35,5 +35,7 @@ public class Job {
     private ZonedDateTime updatedAt;
 
     private String status;
+
+    @Column(columnDefinition="text")
     private String log;
 }


### PR DESCRIPTION
Add cow health to leaderboard and update the job table so that the log field can be arbitrarily long

This change:
```
@Column(columnDefinition="text")
private String log;
```

Changes the SQL data type of the `log` field to `TEXT` which supports arbitrarily long text.  

It is the solution to this problem: the `Job` entity, the `private String log;` may run out of space if the default is used, resulting in this error:

```
 Caused by: org.postgresql.util.PSQLException: ERROR: value too long for type character varying(255)
```

The solution comes from this article:

https://stackoverflow.com/questions/36446201/org-postgresql-util-psqlexception-error-value-too-long-for-type-character-vary

If you don't drop and rebuild the database, you'll need to do this manually to update it:

```
ALTER TABLE jobs ALTER COLUMN log TYPE text;
```
