### PR TITLE
pc - make createdAt on CowDeath automatic

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CowDeathController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CowDeathController.java
@@ -57,7 +57,6 @@ public class CowDeathController extends ApiController {
     public ResponseEntity<String> createCowDeath(
         @ApiParam("commons_id") @RequestParam long commonsId,
         @ApiParam("user_id") @RequestParam long userId,
-        @ApiParam("zonedDateTime") @RequestParam("zonedDateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime zonedDateTime,
         @ApiParam("cowsKilled") @RequestParam Integer cowsKilled,
         @ApiParam("avgHealth") @RequestParam double avgHealth) throws JsonProcessingException {
         
@@ -69,7 +68,6 @@ public class CowDeathController extends ApiController {
         CowDeath createdCowDeath = new CowDeath();
         createdCowDeath.setCommonsId(commonsId);
         createdCowDeath.setUserId(userId);
-        createdCowDeath.setZonedDateTime(zonedDateTime);
         createdCowDeath.setCowsKilled(cowsKilled);
         createdCowDeath.setAvgHealth(avgHealth);
         

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/CowDeath.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/CowDeath.java
@@ -1,14 +1,17 @@
 package edu.ucsb.cs156.happiercows.entities;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 
 import javax.persistence.*;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.AccessLevel;
 
 
 
@@ -17,6 +20,8 @@ import lombok.AccessLevel;
 @NoArgsConstructor
 @Builder
 @Entity(name = "cowdeath")
+@EntityListeners(AuditingEntityListener.class)
+
 public class CowDeath {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,7 +33,8 @@ public class CowDeath {
   @Column(name="user_id")
   private long userId;
   
-  private LocalDateTime zonedDateTime;
+  @CreatedDate
+  private ZonedDateTime createdAt;
   private Integer cowsKilled; 
   private double avgHealth; 
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/CowDeathControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/CowDeathControllerTests.java
@@ -67,7 +67,6 @@ public class CowDeathControllerTests extends ControllerTestCase {
         CowDeath cowDeath = CowDeath.builder()
             .commonsId(1)
             .userId(1)
-            .zonedDateTime(someTime)
             .cowsKilled(10)
             .avgHealth(50)
             .build();
@@ -75,7 +74,6 @@ public class CowDeathControllerTests extends ControllerTestCase {
         CreateCowDeathParams parameters = CreateCowDeathParams.builder()
             .commonsId(1)
             .userId(1)
-            .zonedDateTime(someTime)
             .cowsKilled(10)
             .avgHealth(50)
             .build();
@@ -97,7 +95,7 @@ public class CowDeathControllerTests extends ControllerTestCase {
             .thenReturn(cowDeath);
 
         MvcResult response = mockMvc
-            .perform(post("/api/cowdeath?commonsId=1&userId=1&zonedDateTime=2022-03-05T15:50:10&cowsKilled=10&avgHealth=50").with(csrf())
+            .perform(post("/api/cowdeath?commonsId=1&userId=1&cowsKilled=10&avgHealth=50").with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
                 .content(requestBody))
@@ -118,7 +116,6 @@ public class CowDeathControllerTests extends ControllerTestCase {
         CowDeath cowDeath = CowDeath.builder()
             .commonsId(1)
             .userId(1)
-            .zonedDateTime(someTime)
             .cowsKilled(10)
             .avgHealth(50)
             .build();
@@ -126,7 +123,6 @@ public class CowDeathControllerTests extends ControllerTestCase {
         CreateCowDeathParams parameters = CreateCowDeathParams.builder()
             .commonsId(1)
             .userId(1)
-            .zonedDateTime(someTime)
             .cowsKilled(10)
             .avgHealth(50)
             .build();
@@ -137,7 +133,7 @@ public class CowDeathControllerTests extends ControllerTestCase {
             .thenReturn(cowDeath);
 
         MvcResult response = mockMvc
-            .perform(post("/api/cowdeath?commonsId=1&userId=1&zonedDateTime=2022-03-05T15:50:10&cowsKilled=10&avgHealth=50").with(csrf())
+            .perform(post("/api/cowdeath?commonsId=1&userId=1&cowsKilled=10&avgHealth=50").with(csrf())
                 .contentType(MediaType.APPLICATION_JSON)
                 .characterEncoding("utf-8")
                 .content(requestBody))
@@ -162,7 +158,6 @@ public class CowDeathControllerTests extends ControllerTestCase {
             .id(1)
             .commonsId(1)
             .userId(1)
-            .zonedDateTime(someTime)
             .cowsKilled(10)
             .avgHealth(50)
             .build();
@@ -219,7 +214,6 @@ public class CowDeathControllerTests extends ControllerTestCase {
             .id(1)
             .commonsId(1)
             .userId(1)
-            .zonedDateTime(someTime)
             .cowsKilled(10)
             .avgHealth(50)
             .build();


### PR DESCRIPTION
In this staff PR, we change the date time stamp on the CowDeath to be automatically assigned at the time the record is created.